### PR TITLE
Store Assistant conversations, one file each (#849 P2 — storage layer)

### DIFF
--- a/src/CST.Avalonia.Tests/Services/Ai/AiSessionStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiSessionStoreTests.cs
@@ -81,6 +81,8 @@ public sealed class AiSessionStoreTests : IDisposable
                 Question = null,
                 AskedLine = "«Explain» — Mahāvaggapāḷi 1.1",
                 Answer = "The paragraph opens the Mahāvagga.",
+                // The same answer as the model wrote it: stripped for the screen, marked for the replay.
+                MarkedAnswer = "The paragraph opens the [[Mahāvagga]].",
                 Reasoning = "First, identify the speaker…",
                 Citation = Citation("s0402m.mul.xml", "Mahāvaggapāḷi", "1.1"),
                 Subject = "tena samayena buddho bhagavā",
@@ -117,8 +119,9 @@ public sealed class AiSessionStoreTests : IDisposable
                 Task = AiTask.Ask,
                 Question = "What does bhagavā mean here?",
                 AskedLine = "«Question» — Mahāvaggapāḷi 1.1: What does bhagavā mean here?",
-                // A mid-stream failure keeps what arrived — so the record does too.
-                Answer = "It is an epithet",
+                // A mid-stream failure keeps what arrived — so the record does too, both halves of it.
+                Answer = "It is an epithet: bhagavā",
+                MarkedAnswer = "It is an epithet: [[bhagavā]]",
                 Citation = null,
                 Status = "The provider closed the connection.",
                 Failed = true,
@@ -175,6 +178,10 @@ public sealed class AiSessionStoreTests : IDisposable
         Assert.Null(first.Question);
         Assert.Equal("«Explain» — Mahāvaggapāḷi 1.1", first.AskedLine);
         Assert.Equal("The paragraph opens the Mahāvagga.", first.Answer);
+        // Both halves: the stripped one renders, the marked one is what a later turn replays. A record with
+        // only one of them would decide, for every reloaded session, either that the transcript shows markers
+        // or that the model is fed marker-free examples of its own writing. (#991)
+        Assert.Equal("The paragraph opens the [[Mahāvagga]].", first.MarkedAnswer);
         Assert.Equal("First, identify the speaker…", first.Reasoning);
         Assert.Equal("tena samayena buddho bhagavā", first.Subject);
         Assert.Equal(
@@ -211,9 +218,10 @@ public sealed class AiSessionStoreTests : IDisposable
         var failed = loaded.Turns[1];
         Assert.True(failed.Failed);
         Assert.Equal("The provider closed the connection.", failed.Status);
-        // Partial text stands. A failed turn is not an empty one, and a record that dropped what arrived
-        // would restore the conversation as something the reader never saw.
-        Assert.Equal("It is an epithet", failed.Answer);
+        // Partial text stands, in both halves. A failed turn is not an empty one, and a record that dropped
+        // what arrived would restore the conversation as something the reader never saw.
+        Assert.Equal("It is an epithet: bhagavā", failed.Answer);
+        Assert.Equal("It is an epithet: [[bhagavā]]", failed.MarkedAnswer);
         Assert.Equal("What does bhagavā mean here?", failed.Question);
         Assert.Equal(63000, failed.ElapsedMs);
         Assert.Null(failed.Citation);
@@ -225,6 +233,9 @@ public sealed class AiSessionStoreTests : IDisposable
         Assert.Equal(AiTask.Translate, bare.Task);
         Assert.Null(bare.Sent);
         Assert.Null(bare.Reasoning);
+        // A session written before the marked half existed has only the stripped one — the pre-#991 behaviour
+        // rather than a fault, and the reason this field is nullable.
+        Assert.Null(bare.MarkedAnswer);
         Assert.Null(bare.Status);
         Assert.False(bare.IsPartialPassage);
     }
@@ -281,7 +292,9 @@ public sealed class AiSessionStoreTests : IDisposable
         {
             Assert.True(byId.ContainsKey(id));
             Assert.False(string.IsNullOrEmpty(byId[id].AskedLine));
-            Assert.False(string.IsNullOrEmpty(byId[id].Answer));
+            // The MARKED half is the one a replay sends, so a referenced turn that had only the stripped one
+            // would rebuild a history the live pipeline would not have sent. (#991)
+            Assert.False(string.IsNullOrEmpty(byId[id].MarkedAnswer));
         }
 
         // And the earlier answer appears in the file exactly once — in the turn that produced it, nowhere in

--- a/src/CST.Avalonia.Tests/Services/Ai/AiSessionStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiSessionStoreTests.cs
@@ -1,0 +1,678 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Navigation;
+using CST.Search;
+using Xunit;
+
+namespace CST.Avalonia.Tests.Services.Ai;
+
+/// <summary>
+/// What survives a reopened Assistant conversation, and what happens when a transcript cannot be read.
+/// (#849 P2)
+///
+/// <para>The store is the whole of the persistence layer: the panel is wired to it separately, so everything
+/// here is exercised against a temp directory through the store's own directory seam — the seam
+/// <c>SettingsService</c> has had since #785 and whose absence left <c>ApplicationStateService</c>'s load path
+/// uncovered until #877.</para>
+///
+/// <para>The fixtures are built from the real types (<c>CitationRef</c>, <c>SentContext</c>,
+/// <c>ReadingPositionToken</c>) rather than from hand-written JSON, because the question these tests answer is
+/// whether a turn the panel produced comes back as the turn the panel produced. The one hand-written artefact
+/// is the golden file, and it is checked in for the opposite reason: so that a change to the format shows up
+/// as a diff rather than as a test that still passes.</para>
+/// </summary>
+public sealed class AiSessionStoreTests : IDisposable
+{
+    private readonly string _dir;
+
+    public AiSessionStoreTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), $"assistant-sessions-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* a temp directory */ }
+    }
+
+    private AiSessionStore Store() => new(_dir);
+
+    private string PathFor(string id) => Path.Combine(_dir, id + ".json");
+
+    // ---- fixtures ---------------------------------------------------------------------------------------
+
+    /// <summary>Fixed timestamps and fixed text: a golden file cannot be built from anything else, and a
+    /// round-trip assertion is easier to read when the values are recognisable.</summary>
+    private static readonly DateTimeOffset Created = new(2026, 9, 12, 10, 15, 0, TimeSpan.Zero);
+
+    private static CitationRef Citation(string bookId, string name, string reference) =>
+        new(bookId, name, reference, new[] { new SnippetPageRef(PageEdition.Vri, 1, 23) });
+
+    /// <summary>
+    /// A conversation with the three turns that between them cover every field: a clean one with reasoning,
+    /// notices, usage and a reading position; a failed one with a partial answer and no citation; and a bare
+    /// one, which is what most of the file's nullable members look like in practice.
+    /// </summary>
+    private static AiSession Conversation(string id = "session-one") => new()
+    {
+        Id = id,
+        Name = "Explain · Mahāvaggapāḷi 1.1",
+        Created = Created,
+        LastActive = Created.AddMinutes(12),
+        Turns =
+        {
+            new AiTurnRecord
+            {
+                Task = AiTask.Explain,
+                Question = null,
+                Answer = "The paragraph opens the Mahāvagga.",
+                Reasoning = "First, identify the speaker…",
+                Citation = Citation("s0402m.mul.xml", "Mahāvaggapāḷi", "1.1"),
+                Subject = "tena samayena buddho bhagavā",
+                Notices = { "The word list was not available.", "The apparatus was empty." },
+                IsPartialPassage = true,
+                Usage = "1,024 in · 512 out",
+                Elapsed = "4.2s",
+                Status = "",
+                Failed = false,
+                Sent = new SentContext(
+                    new[]
+                    {
+                        new SentField("Provider", "anthropic"),
+                        new SentField("Model", "claude-opus-4-1"),
+                    },
+                    "You are reading Pāli.",
+                    "Passage: tena samayena…"),
+                ProviderId = "anthropic",
+                ModelId = "claude-opus-4-1",
+                When = Created,
+                ReadingPosition = new ReadingPositionToken
+                {
+                    Above = "para1",
+                    Below = "para2",
+                    Fraction = 0.375,
+                },
+            },
+            new AiTurnRecord
+            {
+                Task = AiTask.Ask,
+                Question = "What does bhagavā mean here?",
+                // A mid-stream failure keeps what arrived — so the record does too.
+                Answer = "It is an epithet",
+                Citation = null,
+                Status = "The provider closed the connection.",
+                Failed = true,
+                Elapsed = "1m 3s",
+                ProviderId = "anthropic",
+                ModelId = "claude-opus-4-1",
+                When = Created.AddMinutes(6),
+            },
+            new AiTurnRecord
+            {
+                Task = AiTask.Translate,
+                Answer = "At that time the Blessed One…",
+                Citation = Citation("s0403m.mul.xml", "Cūḷavaggapāḷi", "2.4"),
+                When = Created.AddMinutes(12),
+            },
+        },
+    };
+
+    // ---- round-trip -------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Every field a turn carries comes back. Asserted one by one rather than by comparing objects: the
+    /// failure this guards against is a single member silently dropped — by a naming policy, an ignore
+    /// condition, or a type that cannot be deserialized — and a whole-object comparison says only that
+    /// something differs.
+    /// </summary>
+    [Fact]
+    public async Task Every_field_of_a_turn_survives_a_round_trip()
+    {
+        var store = Store();
+        var saved = Conversation();
+
+        Assert.True(await store.SaveAsync(saved));
+        var loaded = await store.LoadAsync(saved.Id);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(saved.Id, loaded!.Id);
+        Assert.Equal(saved.Name, loaded.Name);
+        Assert.Equal(saved.Created, loaded.Created);
+        Assert.Equal(saved.LastActive, loaded.LastActive);
+        Assert.Equal(3, loaded.Turns.Count);
+
+        var first = loaded.Turns[0];
+        Assert.Equal(AiTask.Explain, first.Task);
+        Assert.Null(first.Question);
+        Assert.Equal("The paragraph opens the Mahāvagga.", first.Answer);
+        Assert.Equal("First, identify the speaker…", first.Reasoning);
+        Assert.Equal("tena samayena buddho bhagavā", first.Subject);
+        Assert.Equal(
+            new[] { "The word list was not available.", "The apparatus was empty." },
+            first.Notices);
+        Assert.True(first.IsPartialPassage);
+        Assert.Equal("1,024 in · 512 out", first.Usage);
+        Assert.Equal("4.2s", first.Elapsed);
+        Assert.False(first.Failed);
+        Assert.Equal("anthropic", first.ProviderId);
+        Assert.Equal("claude-opus-4-1", first.ModelId);
+        Assert.Equal(Created, first.When);
+
+        // The citation is the structured reference, not the rendered line — it is what makes "take me back"
+        // (P5) possible at all. [fsnow]: "A restored turn should be able to reopen its book and restore the
+        // selection, as something the reader chooses rather than something that happens on load."
+        Assert.NotNull(first.Citation);
+        Assert.Equal("s0402m.mul.xml", first.Citation!.BookId);
+        Assert.Equal("Mahāvaggapāḷi", first.Citation.BookName);
+        Assert.Equal("1.1", first.Citation.NormalizedReference);
+        var page = Assert.Single(first.Citation.Pages);
+        Assert.Equal(PageEdition.Vri, page.Edition);
+        Assert.Equal(1, page.Volume);
+        Assert.Equal(23, page.Number);
+
+        // [fsnow]: "The Assistant's memory should carry the same scroll context saved elsewhere: two anchors
+        // and a fraction between them." — #434's token, not a pixel offset.
+        Assert.NotNull(first.ReadingPosition);
+        Assert.Equal("para1", first.ReadingPosition!.Above);
+        Assert.Equal("para2", first.ReadingPosition.Below);
+        Assert.Equal(0.375, first.ReadingPosition.Fraction);
+
+        var failed = loaded.Turns[1];
+        Assert.True(failed.Failed);
+        Assert.Equal("The provider closed the connection.", failed.Status);
+        // Partial text stands. A failed turn is not an empty one, and a record that dropped what arrived
+        // would restore the conversation as something the reader never saw.
+        Assert.Equal("It is an epithet", failed.Answer);
+        Assert.Equal("What does bhagavā mean here?", failed.Question);
+        Assert.Null(failed.Citation);
+        Assert.Null(failed.ReadingPosition);
+        Assert.Empty(failed.Notices);
+
+        var bare = loaded.Turns[2];
+        Assert.Equal(AiTask.Translate, bare.Task);
+        Assert.Null(bare.Sent);
+        Assert.Null(bare.Reasoning);
+        Assert.False(bare.IsPartialPassage);
+    }
+
+    /// <summary>
+    /// The sent prompt is stored whole. <b>[fsnow]</b> chose <i>"Yes, in full"</i>.
+    ///
+    /// <para>Held as the <c>SentContext</c> type rather than copied field by field, which is what makes P1's
+    /// (#991) addition of the replayed conversation arrive here for free. A record that copied the parts would
+    /// keep saving and loading without them and nothing would fail — the reader would simply find the history
+    /// missing from a restored turn's "Context sent". This test is the other half of that: it will start
+    /// failing the day <c>SentContext</c> gains a member the store's options cannot round-trip.</para>
+    /// </summary>
+    [Fact]
+    public async Task The_sent_prompt_is_stored_in_full()
+    {
+        var store = Store();
+        var saved = Conversation();
+
+        await store.SaveAsync(saved);
+        var loaded = await store.LoadAsync(saved.Id);
+
+        var sent = loaded!.Turns[0].Sent;
+        Assert.NotNull(sent);
+        Assert.Equal("You are reading Pāli.", sent!.SystemPrompt);
+        Assert.Equal("Passage: tena samayena…", sent.UserContent);
+        Assert.Equal(2, sent.Fields.Count);
+        Assert.Equal("Provider", sent.Fields[0].Name);
+        Assert.Equal("anthropic", sent.Fields[0].Value);
+        Assert.Equal("Model", sent.Fields[1].Name);
+        Assert.Equal("claude-opus-4-1", sent.Fields[1].Value);
+    }
+
+    /// <summary>
+    /// A property a NEWER build wrote is carried through rather than stripped. (#883's mechanism.)
+    ///
+    /// <para>A session file is rewritten at the end of every turn, so without this one launch of an older
+    /// build over a newer build's session silently drops whatever that build added — and <b>[fsnow]</b>'s
+    /// <i>"Forever, no cap"</i> means these files outlive the builds that wrote them by design.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_property_this_build_does_not_know_survives_a_round_trip()
+    {
+        File.WriteAllText(PathFor("session-future"), """
+            {
+              "version": "1.0",
+              "id": "session-future",
+              "name": "From a later build",
+              "somethingNewer": { "kept": true },
+              "turns": [ { "task": "Explain", "answer": "Hello", "turnFieldFromLater": 7 } ]
+            }
+            """);
+
+        var store = Store();
+        var loaded = await store.LoadAsync("session-future");
+        Assert.NotNull(loaded);
+        await store.SaveAsync(loaded!);
+
+        var rewritten = File.ReadAllText(PathFor("session-future"));
+        Assert.Contains("somethingNewer", rewritten);
+        Assert.Contains("turnFieldFromLater", rewritten);
+    }
+
+    /// <summary>An unnamed session is legal. Naming is P3's ("Auto from the first turn, renamable"), and a
+    /// store that required a name would make the first turn's write order significant for no reason.</summary>
+    [Fact]
+    public async Task A_session_with_no_turns_and_no_name_round_trips()
+    {
+        var store = Store();
+        var session = new AiSession { Id = "empty-one", Created = Created, LastActive = Created };
+
+        Assert.True(await store.SaveAsync(session));
+        var loaded = await store.LoadAsync("empty-one");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(string.Empty, loaded!.Name);
+        Assert.Empty(loaded.Turns);
+    }
+
+    [Fact]
+    public async Task A_session_that_was_never_written_loads_as_null()
+    {
+        Assert.Null(await Store().LoadAsync("never-written"));
+    }
+
+    /// <summary>
+    /// A file whose collections are an explicit <c>null</c> loads as empty ones rather than as a
+    /// <c>NullReferenceException</c> two layers later.
+    ///
+    /// <para>A property initializer does not survive an explicit null in the file — <c>"turns": null</c> sets
+    /// the member to null, initializer and all — and the crash then lands in the listing or in the panel
+    /// rebuilding the transcript, which is the "cannot open the panel" failure everything else here avoids.
+    /// Nothing this build writes produces such a file; a hand-edit or a truncating tool does.</para>
+    /// </summary>
+    [Fact]
+    public async Task Collections_written_as_null_load_as_empty()
+    {
+        File.WriteAllText(PathFor("session-nulls"), """
+            {
+              "id": "session-nulls",
+              "name": null,
+              "turns": [ { "task": "Explain", "notices": null }, null ]
+            }
+            """);
+
+        var store = Store();
+        var loaded = await store.LoadAsync("session-nulls");
+
+        Assert.NotNull(loaded);
+        Assert.Equal(string.Empty, loaded!.Name);
+        Assert.Single(loaded.Turns);
+        Assert.Empty(loaded.Turns[0].Notices);
+
+        var row = Assert.Single(await store.ListAsync());
+        Assert.Equal(1, row.TurnCount);
+        Assert.Empty(row.BookIds);
+    }
+
+    // ---- the list ---------------------------------------------------------------------------------------
+
+    /// <summary>Newest-active first (§3.3) — the order the session picker shows, and what "restore the last
+    /// session" resolves against.</summary>
+    [Fact]
+    public async Task Sessions_are_listed_newest_active_first()
+    {
+        var store = Store();
+
+        await store.SaveAsync(new AiSession { Id = "older", LastActive = Created });
+        await store.SaveAsync(new AiSession { Id = "newest", LastActive = Created.AddHours(3) });
+        await store.SaveAsync(new AiSession { Id = "middle", LastActive = Created.AddHours(1) });
+
+        var rows = await store.ListAsync();
+
+        Assert.Equal(new[] { "newest", "middle", "older" }, rows.Select(r => r.Id));
+    }
+
+    /// <summary>
+    /// A row says what the conversation was about: the distinct books its citations name, in the order they
+    /// first appear — which a reader recognises long before a name they never typed.
+    /// </summary>
+    [Fact]
+    public async Task A_row_names_the_distinct_books_its_citations_name()
+    {
+        var store = Store();
+        var session = Conversation();
+
+        // A fourth turn back in the first book: the list must not repeat it, and must not reorder on account
+        // of it either.
+        session.Turns.Add(new AiTurnRecord
+        {
+            Task = AiTask.Grammar,
+            Citation = Citation("s0402m.mul.xml", "Mahāvaggapāḷi", "1.2"),
+            When = Created.AddMinutes(20),
+        });
+
+        await store.SaveAsync(session);
+        var row = Assert.Single(await store.ListAsync());
+
+        Assert.Equal("session-one", row.Id);
+        Assert.Equal("Explain · Mahāvaggapāḷi 1.1", row.Name);
+        Assert.Equal(Created, row.Created);
+        Assert.Equal(Created.AddMinutes(12), row.LastActive);
+        Assert.Equal(4, row.TurnCount);
+        // The failed turn has no citation and contributes nothing, which is the ordinary case rather than a
+        // corner of it: a turn that failed before the context was assembled has no book to name.
+        Assert.Equal(new[] { "s0402m.mul.xml", "s0403m.mul.xml" }, row.BookIds);
+    }
+
+    [Fact]
+    public async Task Listing_a_directory_that_is_not_there_is_not_an_error()
+    {
+        var absent = Path.Combine(_dir, "not-created-yet");
+        Assert.Empty(await new AiSessionStore(absent).ListAsync());
+    }
+
+    // ---- delete -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Delete_removes_the_file()
+    {
+        var store = Store();
+        await store.SaveAsync(Conversation());
+
+        Assert.True(await store.DeleteAsync("session-one"));
+        Assert.False(File.Exists(PathFor("session-one")));
+        Assert.Empty(await store.ListAsync());
+    }
+
+    /// <summary>
+    /// Deleting a session that is not there is not an error.
+    ///
+    /// <para>The id can only have come from a list the reader was looking at or from
+    /// <c>ActiveAssistantSessionId</c>, and both can name a session that has since gone — a second window, a
+    /// file deleted by hand. An error for work already done is worse than silence.</para>
+    /// </summary>
+    [Fact]
+    public async Task Deleting_a_session_that_is_not_there_is_not_an_error()
+    {
+        Assert.False(await Store().DeleteAsync("never-existed"));
+    }
+
+    // ---- unreadable files -------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A transcript that cannot be read is kept, reported, and does not throw.
+    ///
+    /// <para>Nothing else would keep it: the next turn in that conversation rewrites the file. The panel's
+    /// notice is what the event is for — the log alone leaves the reader with an empty panel and no
+    /// explanation. (#877's pattern, on a file whose loss is a conversation rather than a window layout.)</para>
+    /// </summary>
+    [Fact]
+    public async Task A_truncated_session_file_is_kept_aside_and_reported()
+    {
+        File.WriteAllText(PathFor("session-broken"), """{ "id": "session-broken", "turns": [ { "task": """);
+
+        var store = Store();
+        var reports = new List<AiSessionUnreadable>();
+        store.Unreadable += reports.Add;
+
+        Assert.Null(await store.LoadAsync("session-broken"));
+
+        var report = Assert.Single(reports);
+        Assert.Equal("session-broken", report.Id);
+        Assert.False(string.IsNullOrWhiteSpace(report.Error));
+
+        var kept = Directory.GetFiles(_dir, "session-broken.unreadable-*.json");
+        Assert.Single(kept);
+        Assert.Equal(kept[0], report.KeptPath);
+        Assert.Contains("session-broken", File.ReadAllText(kept[0]));
+        Assert.False(File.Exists(PathFor("session-broken")));
+    }
+
+    /// <summary>A file holding the literal token <c>null</c> deserializes to null without throwing, where an
+    /// empty one throws. Both are "this is not a session", and both must take the preserve path — which half
+    /// of System.Text.Json's behaviour was hit is not the reader's problem.</summary>
+    [Fact]
+    public async Task A_session_file_holding_null_is_kept_aside_too()
+    {
+        File.WriteAllText(PathFor("session-null"), "null");
+
+        var store = Store();
+        var reports = new List<AiSessionUnreadable>();
+        store.Unreadable += reports.Add;
+
+        Assert.Null(await store.LoadAsync("session-null"));
+        Assert.Single(reports);
+        Assert.Single(Directory.GetFiles(_dir, "session-null.unreadable-*.json"));
+    }
+
+    /// <summary>One broken transcript must not cost the reader the list of the others.</summary>
+    [Fact]
+    public async Task An_unreadable_file_does_not_cost_the_listing_the_other_sessions()
+    {
+        var store = Store();
+        await store.SaveAsync(new AiSession { Id = "good-one", LastActive = Created });
+        File.WriteAllText(PathFor("bad-one"), "{ not json");
+
+        var reports = new List<AiSessionUnreadable>();
+        store.Unreadable += reports.Add;
+
+        var rows = await store.ListAsync();
+
+        Assert.Equal("good-one", Assert.Single(rows).Id);
+        Assert.Equal("bad-one", Assert.Single(reports).Id);
+    }
+
+    /// <summary>
+    /// A kept file is never listed or re-reported. Without this the same broken transcript would be found,
+    /// moved and announced once per launch — and each launch would leave another copy of it.
+    /// </summary>
+    [Fact]
+    public async Task A_kept_unreadable_file_is_not_itself_read_as_a_session()
+    {
+        var store = Store();
+        File.WriteAllText(PathFor("bad-one"), "{ not json");
+
+        var reports = new List<AiSessionUnreadable>();
+        store.Unreadable += reports.Add;
+
+        Assert.Empty(await store.ListAsync());
+        Assert.Single(reports);
+
+        // Second pass: the kept file is sitting in the directory, and is not a session.
+        reports.Clear();
+        Assert.Empty(await store.ListAsync());
+        Assert.Empty(reports);
+        Assert.Single(Directory.GetFiles(_dir, "bad-one.unreadable-*.json"));
+    }
+
+    // ---- writing ----------------------------------------------------------------------------------------
+
+    /// <summary>The temp file is an implementation detail and must not outlive the save — a directory the
+    /// listing walks is no place to leave litter, and a <c>.tmp</c> left behind is the visible half of a
+    /// promote that did not happen.</summary>
+    [Fact]
+    public async Task A_save_leaves_no_temporary_file_behind()
+    {
+        var store = Store();
+
+        await store.SaveAsync(Conversation());
+        await store.SaveAsync(Conversation());
+
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
+        Assert.Single(Directory.GetFiles(_dir, "*.json"));
+    }
+
+    /// <summary>
+    /// A leftover temp file from an interrupted save is never promoted over the session that is there.
+    ///
+    /// <para>This is the shape of the bug STATE-2 fixed in <c>ApplicationStateService</c>, where two saves
+    /// shared one <c>.tmp</c> path and a half-written file could be promoted over good state. Here the write
+    /// always produces the temp's contents itself before replacing, so a stale temp is overwritten rather than
+    /// trusted.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_leftover_temporary_file_is_never_promoted_over_a_good_session()
+    {
+        var store = Store();
+        await store.SaveAsync(Conversation());
+
+        File.WriteAllText(PathFor("session-one") + ".tmp", "{ half a session");
+
+        var again = Conversation();
+        again.Name = "Renamed";
+        Assert.True(await store.SaveAsync(again));
+
+        var loaded = await store.LoadAsync("session-one");
+        Assert.NotNull(loaded);
+        Assert.Equal("Renamed", loaded!.Name);
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
+    }
+
+    /// <summary>
+    /// An id that would address a path of its own choosing is refused, on every operation.
+    ///
+    /// <para>Every id reaching the store comes from outside it — a directory listing,
+    /// <c>ActiveAssistantSessionId</c> in a file the reader can edit, and later whatever the local API hands
+    /// in — and the operations here are read, overwrite and delete.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("../escaped")]
+    [InlineData("../../settings")]
+    [InlineData("sub/dir")]
+    [InlineData("has space")]
+    [InlineData("")]
+    public async Task An_id_that_is_not_a_plain_file_name_is_refused(string id)
+    {
+        var store = Store();
+
+        Assert.False(await store.SaveAsync(new AiSession { Id = id }));
+        Assert.Null(await store.LoadAsync(id));
+        Assert.False(await store.DeleteAsync(id));
+
+        Assert.Empty(Directory.GetFiles(_dir, "*", SearchOption.AllDirectories));
+    }
+
+    // ---- the format itself ------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The on-disk format, pinned to a checked-in file.
+    ///
+    /// <para>Everything else here would still pass if the format changed wholesale — a round-trip is happy as
+    /// long as both ends move together, which is exactly what makes an old session file stop loading while the
+    /// suite stays green. This is the test that makes such a change a <b>diff</b>, which is the only form in
+    /// which a "forever, no cap" format change can be reviewed.</para>
+    ///
+    /// <para><b>Expect it to fail when P1 (#991) lands</b>: adding the replayed conversation to
+    /// <c>SentContext</c> changes what a stored turn writes. That is the mechanism working. Regenerate the
+    /// file from the path the failure message names, and read the diff before accepting it.</para>
+    ///
+    /// <para>It uses <c>AiSessionStore.JsonOptions</c> rather than a copy: a mirrored copy cannot detect drift
+    /// from the original, which is the one thing it most needs to detect. (#787)</para>
+    /// </summary>
+    [Fact]
+    public void The_on_disk_format_matches_the_golden_file()
+    {
+        var session = Conversation("golden-session");
+        var actual = Normalize(JsonSerializer.Serialize(session, AiSessionStore.JsonOptions));
+
+        var goldenPath = Path.Combine(
+            RepoRoot(), "src", "CST.Avalonia.Tests", "Services", "Ai", "assistant-session.golden.json");
+
+        if (!File.Exists(goldenPath) || Normalize(File.ReadAllText(goldenPath)) != actual)
+        {
+            var written = Path.Combine(Path.GetTempPath(), "assistant-session.actual.json");
+            File.WriteAllText(written, actual);
+
+            Assert.Fail(
+                $"The stored session format no longer matches {goldenPath}. "
+                + $"The format this build writes has been put at {written}; review the diff, and if the "
+                + "change is intended copy it over the golden file.");
+        }
+
+        // And the golden file loads back — a format pinned but unreadable would be worse than no pin at all.
+        var loaded = JsonSerializer.Deserialize<AiSession>(
+            File.ReadAllText(goldenPath), AiSessionStore.JsonOptions);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(3, loaded!.Turns.Count);
+        Assert.Equal("Mahāvaggapāḷi", loaded.Turns[0].Citation!.BookName);
+        Assert.Equal(0.375, loaded.Turns[0].ReadingPosition!.Fraction);
+        Assert.NotNull(loaded.Turns[0].Sent);
+    }
+
+    /// <summary>
+    /// Enums are written as names. <c>AiTask</c> and <c>PageEdition</c> are positional, and a session file
+    /// written today will be read by builds that may have inserted a preset or an edition: numbers would
+    /// silently re-point, names cannot.
+    /// </summary>
+    [Fact]
+    public void Enums_are_written_as_names_rather_than_numbers()
+    {
+        var json = JsonSerializer.Serialize(Conversation(), AiSessionStore.JsonOptions);
+
+        Assert.Contains("\"task\": \"Explain\"", json);
+        Assert.Contains("\"edition\": \"Vri\"", json);
+    }
+
+    /// <summary>
+    /// Pāli is written as Pāli. These files are read by hand when an answer looks wrong, which is the moment
+    /// the passage needs to be legible rather than a page of <c>ā</c>. The HTML-sensitive characters are
+    /// still escaped — <c>JavaScriptEncoder</c> escapes those whatever range it is given.
+    /// </summary>
+    [Fact]
+    public void Pali_text_is_stored_readable_and_html_sensitive_characters_are_still_escaped()
+    {
+        var session = Conversation();
+        session.Turns[0].Answer = "bhagavā <b>&</b>";
+
+        var json = JsonSerializer.Serialize(session, AiSessionStore.JsonOptions);
+
+        Assert.Contains("bhagavā", json);
+        Assert.DoesNotContain("\\u0101", json);   // ā, escaped by the default encoder
+        Assert.DoesNotContain("<b>", json);       // still escaped, whatever range is allowed
+        Assert.Contains("\\u003C", json);
+    }
+
+    /// <summary>
+    /// The one line #849 adds to <c>application-state.json</c>: which conversation to reopen.
+    ///
+    /// <para><b>[fsnow]</b> chose <i>"Restore the last session silently"</i>. Asserted through the state
+    /// service's own options — the same no-mirroring rule (#787) — because the risk is the usual one for that
+    /// file: an ignore condition or naming policy that drops the property while every round-trip in the suite
+    /// still passes.</para>
+    /// </summary>
+    [Fact]
+    public void The_active_session_id_round_trips_through_the_state_file()
+    {
+        var json = JsonSerializer.Serialize(
+            new ApplicationState { ActiveAssistantSessionId = "session-one" },
+            ApplicationStateService.JsonOptions);
+
+        Assert.Contains("\"activeAssistantSessionId\": \"session-one\"", json);
+
+        var state = JsonSerializer.Deserialize<ApplicationState>(json, ApplicationStateService.JsonOptions);
+        Assert.Equal("session-one", state!.ActiveAssistantSessionId);
+
+        // No session yet is null, not an empty string: the store is asked for a session only when there is one
+        // to ask for, and WhenWritingDefault keeps the property out of the file entirely until there is.
+        var fresh = JsonSerializer.Serialize(new ApplicationState(), ApplicationStateService.JsonOptions);
+        Assert.DoesNotContain("activeAssistantSessionId", fresh);
+    }
+
+    // ---- helpers ----------------------------------------------------------------------------------------
+
+    private static string Normalize(string json) => json.Replace("\r\n", "\n").TrimEnd('\n');
+
+    /// <summary>Walk up to the repository root, the way the other tests that read checked-in files do.</summary>
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/AiSessionStoreTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiSessionStoreTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using CST.Avalonia.Models;
 using CST.Avalonia.Services;
 using CST.Avalonia.Services.Ai;
 using CST.Navigation;
-using CST.Search;
 using Xunit;
 
 namespace CST.Avalonia.Tests.Services.Ai;
@@ -22,11 +22,10 @@ namespace CST.Avalonia.Tests.Services.Ai;
 /// <c>SettingsService</c> has had since #785 and whose absence left <c>ApplicationStateService</c>'s load path
 /// uncovered until #877.</para>
 ///
-/// <para>The fixtures are built from the real types (<c>CitationRef</c>, <c>SentContext</c>,
-/// <c>ReadingPositionToken</c>) rather than from hand-written JSON, because the question these tests answer is
-/// whether a turn the panel produced comes back as the turn the panel produced. The one hand-written artefact
-/// is the golden file, and it is checked in for the opposite reason: so that a change to the format shows up
-/// as a diff rather than as a test that still passes.</para>
+/// <para>The fixtures are built from the stored types rather than from hand-written JSON, because the question
+/// these tests answer is whether a turn the panel produced comes back as the turn the panel produced. The one
+/// hand-written artefact is the golden file, and it is checked in for the opposite reason: so that a change to
+/// the format shows up as a diff rather than as a test that still passes.</para>
 /// </summary>
 public sealed class AiSessionStoreTests : IDisposable
 {
@@ -49,17 +48,23 @@ public sealed class AiSessionStoreTests : IDisposable
 
     // ---- fixtures ---------------------------------------------------------------------------------------
 
-    /// <summary>Fixed timestamps and fixed text: a golden file cannot be built from anything else, and a
-    /// round-trip assertion is easier to read when the values are recognisable.</summary>
+    /// <summary>Fixed timestamps, fixed ids and fixed text: a golden file cannot be built from anything else,
+    /// and a round-trip assertion is easier to read when the values are recognisable.</summary>
     private static readonly DateTimeOffset Created = new(2026, 9, 12, 10, 15, 0, TimeSpan.Zero);
 
-    private static CitationRef Citation(string bookId, string name, string reference) =>
-        new(bookId, name, reference, new[] { new SnippetPageRef(PageEdition.Vri, 1, 23) });
+    private static AiCitationRecord Citation(string bookId, string name, string reference) => new()
+    {
+        BookId = bookId,
+        BookName = name,
+        NormalizedReference = reference,
+        Pages = { new AiPageRecord { Edition = PageEdition.Vri, Volume = 1, Number = 23 } },
+    };
 
     /// <summary>
     /// A conversation with the three turns that between them cover every field: a clean one with reasoning,
-    /// notices, usage and a reading position; a failed one with a partial answer and no citation; and a bare
-    /// one, which is what most of the file's nullable members look like in practice.
+    /// notices, usage and a reading position; a failed follow-up with a partial answer, no citation and a
+    /// replayed history; and a bare one, which is what most of the file's nullable members look like in
+    /// practice.
     /// </summary>
     private static AiSession Conversation(string id = "session-one") => new()
     {
@@ -71,26 +76,31 @@ public sealed class AiSessionStoreTests : IDisposable
         {
             new AiTurnRecord
             {
+                Id = "turn-one",
                 Task = AiTask.Explain,
                 Question = null,
+                AskedLine = "«Explain» — Mahāvaggapāḷi 1.1",
                 Answer = "The paragraph opens the Mahāvagga.",
                 Reasoning = "First, identify the speaker…",
                 Citation = Citation("s0402m.mul.xml", "Mahāvaggapāḷi", "1.1"),
                 Subject = "tena samayena buddho bhagavā",
                 Notices = { "The word list was not available.", "The apparatus was empty." },
                 IsPartialPassage = true,
-                Usage = "1,024 in · 512 out",
-                Elapsed = "4.2s",
+                InputTokens = 1024,
+                OutputTokens = 512,
+                ElapsedMs = 4200,
                 Status = "",
                 Failed = false,
-                Sent = new SentContext(
-                    new[]
+                Sent = new AiSentRecord
+                {
+                    Fields =
                     {
-                        new SentField("Provider", "anthropic"),
-                        new SentField("Model", "claude-opus-4-1"),
+                        new AiSentFieldRecord { Name = "Provider", Value = "anthropic" },
+                        new AiSentFieldRecord { Name = "Model", Value = "claude-opus-4-1" },
                     },
-                    "You are reading Pāli.",
-                    "Passage: tena samayena…"),
+                    SystemPrompt = "You are reading Pāli.",
+                    UserContent = "Passage: tena samayena…",
+                },
                 ProviderId = "anthropic",
                 ModelId = "claude-opus-4-1",
                 When = Created,
@@ -103,20 +113,30 @@ public sealed class AiSessionStoreTests : IDisposable
             },
             new AiTurnRecord
             {
+                Id = "turn-two",
                 Task = AiTask.Ask,
                 Question = "What does bhagavā mean here?",
+                AskedLine = "«Question» — Mahāvaggapāḷi 1.1: What does bhagavā mean here?",
                 // A mid-stream failure keeps what arrived — so the record does too.
                 Answer = "It is an epithet",
                 Citation = null,
                 Status = "The provider closed the connection.",
                 Failed = true,
-                Elapsed = "1m 3s",
+                ElapsedMs = 63000,
+                Sent = new AiSentRecord
+                {
+                    SystemPrompt = "You are reading Pāli.",
+                    UserContent = "Passage: tena samayena… What does bhagavā mean here?",
+                    // The replayed conversation, by reference. Never the earlier answer's text.
+                    ReplayedTurnIds = { "turn-one" },
+                },
                 ProviderId = "anthropic",
                 ModelId = "claude-opus-4-1",
                 When = Created.AddMinutes(6),
             },
             new AiTurnRecord
             {
+                Id = "turn-three",
                 Task = AiTask.Translate,
                 Answer = "At that time the Blessed One…",
                 Citation = Citation("s0403m.mul.xml", "Cūḷavaggapāḷi", "2.4"),
@@ -150,8 +170,10 @@ public sealed class AiSessionStoreTests : IDisposable
         Assert.Equal(3, loaded.Turns.Count);
 
         var first = loaded.Turns[0];
+        Assert.Equal("turn-one", first.Id);
         Assert.Equal(AiTask.Explain, first.Task);
         Assert.Null(first.Question);
+        Assert.Equal("«Explain» — Mahāvaggapāḷi 1.1", first.AskedLine);
         Assert.Equal("The paragraph opens the Mahāvagga.", first.Answer);
         Assert.Equal("First, identify the speaker…", first.Reasoning);
         Assert.Equal("tena samayena buddho bhagavā", first.Subject);
@@ -159,8 +181,9 @@ public sealed class AiSessionStoreTests : IDisposable
             new[] { "The word list was not available.", "The apparatus was empty." },
             first.Notices);
         Assert.True(first.IsPartialPassage);
-        Assert.Equal("1,024 in · 512 out", first.Usage);
-        Assert.Equal("4.2s", first.Elapsed);
+        Assert.Equal(1024, first.InputTokens);
+        Assert.Equal(512, first.OutputTokens);
+        Assert.Equal(4200, first.ElapsedMs);
         Assert.False(first.Failed);
         Assert.Equal("anthropic", first.ProviderId);
         Assert.Equal("claude-opus-4-1", first.ModelId);
@@ -192,25 +215,27 @@ public sealed class AiSessionStoreTests : IDisposable
         // would restore the conversation as something the reader never saw.
         Assert.Equal("It is an epithet", failed.Answer);
         Assert.Equal("What does bhagavā mean here?", failed.Question);
+        Assert.Equal(63000, failed.ElapsedMs);
         Assert.Null(failed.Citation);
         Assert.Null(failed.ReadingPosition);
+        Assert.Null(failed.InputTokens);
         Assert.Empty(failed.Notices);
 
         var bare = loaded.Turns[2];
         Assert.Equal(AiTask.Translate, bare.Task);
         Assert.Null(bare.Sent);
         Assert.Null(bare.Reasoning);
+        Assert.Null(bare.Status);
         Assert.False(bare.IsPartialPassage);
     }
 
     /// <summary>
     /// The sent prompt is stored whole. <b>[fsnow]</b> chose <i>"Yes, in full"</i>.
     ///
-    /// <para>Held as the <c>SentContext</c> type rather than copied field by field, which is what makes P1's
-    /// (#991) addition of the replayed conversation arrive here for free. A record that copied the parts would
-    /// keep saving and loading without them and nothing would fail — the reader would simply find the history
-    /// missing from a restored turn's "Context sent". This test is the other half of that: it will start
-    /// failing the day <c>SentContext</c> gains a member the store's options cannot round-trip.</para>
+    /// <para>In a stored type of the format's own, not the live <c>SentContext</c>: that one is a positional
+    /// record with no extension data and, since #991, a computed <c>HasHistory</c> getter, so storing it
+    /// directly both wrote a derived boolean into a "forever" format and dropped a newer build's nested field
+    /// on the first rewrite. Mapping the two is the wiring layer's job.</para>
     /// </summary>
     [Fact]
     public async Task The_sent_prompt_is_stored_in_full()
@@ -233,14 +258,52 @@ public sealed class AiSessionStoreTests : IDisposable
     }
 
     /// <summary>
-    /// A property a NEWER build wrote is carried through rather than stripped. (#883's mechanism.)
+    /// The replayed conversation is stored by reference, and the ids resolve.
     ///
-    /// <para>A session file is rewritten at the end of every turn, so without this one launch of an older
-    /// build over a newer build's session silently drops whatever that build added — and <b>[fsnow]</b>'s
-    /// <i>"Forever, no cap"</i> means these files outlive the builds that wrote them by design.</para>
+    /// <para>#991 replays every earlier turn that has an answer, so storing that history by value puts every
+    /// earlier answer inside every later turn — turn 30 of a 30-turn conversation carrying 29 of them, 435
+    /// copies across the file. None of it is new information: a written turn never changes, so the ids plus
+    /// each referenced turn's <c>AskedLine</c> and <c>Answer</c> rebuild what was sent exactly.</para>
     /// </summary>
     [Fact]
-    public async Task A_property_this_build_does_not_know_survives_a_round_trip()
+    public async Task The_replayed_history_is_stored_as_turn_ids_rather_than_as_copies()
+    {
+        var store = Store();
+        await store.SaveAsync(Conversation());
+        var loaded = await store.LoadAsync("session-one");
+
+        var followUp = loaded!.Turns[1];
+        Assert.Equal(new[] { "turn-one" }, followUp.Sent!.ReplayedTurnIds);
+
+        // Every replayed id names a turn in this session, and that turn carries what the replay needs.
+        var byId = loaded.Turns.ToDictionary(t => t.Id);
+        foreach (var id in followUp.Sent.ReplayedTurnIds)
+        {
+            Assert.True(byId.ContainsKey(id));
+            Assert.False(string.IsNullOrEmpty(byId[id].AskedLine));
+            Assert.False(string.IsNullOrEmpty(byId[id].Answer));
+        }
+
+        // And the earlier answer appears in the file exactly once — in the turn that produced it, nowhere in
+        // the turn that replayed it. That is the whole point of the ids.
+        var onDisk = File.ReadAllText(PathFor("session-one"));
+        Assert.Equal(1, onDisk.Split("The paragraph opens the Mahāvagga.").Length - 1);
+        Assert.Equal(1, onDisk.Split("«Explain» — Mahāvaggapāḷi 1.1").Length - 1);
+    }
+
+    /// <summary>
+    /// A property a NEWER build wrote is carried through rather than stripped — <b>at every level</b>,
+    /// including inside a stored citation and a stored sent record. (#883's mechanism.)
+    ///
+    /// <para>A session file is rewritten at the end of every turn, so without this one launch of an older
+    /// build over a newer build's session silently drops whatever that build added, and <b>[fsnow]</b>'s
+    /// <i>"Forever, no cap"</i> means these files outlive the builds that wrote them by design. The nested
+    /// levels are here because the first cut stored the live positional records, which have no extension data:
+    /// a review probe showed a newer build's field inside <c>sent</c> vanishing on the first rewrite while the
+    /// outer levels round-tripped perfectly.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_property_this_build_does_not_know_survives_a_round_trip_at_every_level()
     {
         File.WriteAllText(PathFor("session-future"), """
             {
@@ -248,7 +311,28 @@ public sealed class AiSessionStoreTests : IDisposable
               "id": "session-future",
               "name": "From a later build",
               "somethingNewer": { "kept": true },
-              "turns": [ { "task": "Explain", "answer": "Hello", "turnFieldFromLater": 7 } ]
+              "turns": [
+                {
+                  "task": "Explain",
+                  "answer": "Hello",
+                  "turnFieldFromLater": 7,
+                  "citation": {
+                    "bookId": "s0402m.mul.xml",
+                    "bookName": "Mahāvaggapāḷi",
+                    "normalizedReference": "1.1",
+                    "pages": [ { "edition": "Vri", "volume": 1, "number": 2, "pageFieldFromLater": "p" } ],
+                    "citationFieldFromLater": true
+                  },
+                  "sent": {
+                    "fields": [ { "name": "Provider", "value": "x", "fieldFieldFromLater": 1 } ],
+                    "systemPrompt": "s",
+                    "userContent": "u",
+                    "sentFieldFromLater": [ 1, 2 ]
+                  }
+                }
+              ],
+              "compactions": [ { "when": "2026-09-12T10:15:00+00:00", "summary": "s",
+                                 "summarisedTurnIds": [ "t" ], "compactionFieldFromLater": 0 } ]
             }
             """);
 
@@ -260,6 +344,35 @@ public sealed class AiSessionStoreTests : IDisposable
         var rewritten = File.ReadAllText(PathFor("session-future"));
         Assert.Contains("somethingNewer", rewritten);
         Assert.Contains("turnFieldFromLater", rewritten);
+        Assert.Contains("citationFieldFromLater", rewritten);
+        Assert.Contains("pageFieldFromLater", rewritten);
+        Assert.Contains("sentFieldFromLater", rewritten);
+        Assert.Contains("fieldFieldFromLater", rewritten);
+        Assert.Contains("compactionFieldFromLater", rewritten);
+    }
+
+    /// <summary>The P4 slot round-trips, so the format does not have to change when compaction arrives. Nothing
+    /// writes it yet. <b>[fsnow]</b>: <i>"Manual and auto at a fraction of context length"</i>,
+    /// <i>"Last 4 turns"</i>.</summary>
+    [Fact]
+    public async Task A_compaction_summary_round_trips()
+    {
+        var store = Store();
+        var session = Conversation();
+        session.Compactions.Add(new AiCompactionRecord
+        {
+            When = Created.AddMinutes(30),
+            Summary = "Twelve earlier turns, about the opening of the Mahāvagga.",
+            SummarisedTurnIds = { "turn-one", "turn-two" },
+        });
+
+        await store.SaveAsync(session);
+        var loaded = await store.LoadAsync(session.Id);
+
+        var compaction = Assert.Single(loaded!.Compactions);
+        Assert.Equal(Created.AddMinutes(30), compaction.When);
+        Assert.Equal("Twelve earlier turns, about the opening of the Mahāvagga.", compaction.Summary);
+        Assert.Equal(new[] { "turn-one", "turn-two" }, compaction.SummarisedTurnIds);
     }
 
     /// <summary>An unnamed session is legal. Naming is P3's ("Auto from the first turn, renamable"), and a
@@ -276,6 +389,7 @@ public sealed class AiSessionStoreTests : IDisposable
         Assert.NotNull(loaded);
         Assert.Equal(string.Empty, loaded!.Name);
         Assert.Empty(loaded.Turns);
+        Assert.Empty(loaded.Compactions);
     }
 
     [Fact]
@@ -289,9 +403,10 @@ public sealed class AiSessionStoreTests : IDisposable
     /// <c>NullReferenceException</c> two layers later.
     ///
     /// <para>A property initializer does not survive an explicit null in the file — <c>"turns": null</c> sets
-    /// the member to null, initializer and all — and the crash then lands in the listing or in the panel
-    /// rebuilding the transcript, which is the "cannot open the panel" failure everything else here avoids.
-    /// Nothing this build writes produces such a file; a hand-edit or a truncating tool does.</para>
+    /// the member to null, initializer and all — and the crash then lands in the listing, or in the panel
+    /// rebuilding the transcript, or in <c>Describe(citation)</c> iterating the pages. Nothing this build
+    /// writes produces such a file; a hand-edit does, and a hand-edited session is a thing a reader may well
+    /// try once the format is documented.</para>
     /// </summary>
     [Fact]
     public async Task Collections_written_as_null_load_as_empty()
@@ -300,7 +415,16 @@ public sealed class AiSessionStoreTests : IDisposable
             {
               "id": "session-nulls",
               "name": null,
-              "turns": [ { "task": "Explain", "notices": null }, null ]
+              "compactions": null,
+              "turns": [
+                {
+                  "task": "Explain",
+                  "notices": null,
+                  "citation": { "bookId": "b", "bookName": "n", "normalizedReference": "1", "pages": null },
+                  "sent": { "fields": null, "systemPrompt": null, "userContent": null, "replayedTurnIds": null }
+                },
+                null
+              ]
             }
             """);
 
@@ -309,12 +433,37 @@ public sealed class AiSessionStoreTests : IDisposable
 
         Assert.NotNull(loaded);
         Assert.Equal(string.Empty, loaded!.Name);
+        Assert.Empty(loaded.Compactions);
         Assert.Single(loaded.Turns);
-        Assert.Empty(loaded.Turns[0].Notices);
+
+        var turn = loaded.Turns[0];
+        Assert.Empty(turn.Notices);
+        Assert.Empty(turn.Citation!.Pages);
+        Assert.Empty(turn.Sent!.Fields);
+        Assert.Empty(turn.Sent.ReplayedTurnIds);
+        Assert.Equal(string.Empty, turn.Sent.SystemPrompt);
+        // A turn with no id of its own gets one, so nothing can point at "" and mean two different turns.
+        Assert.False(string.IsNullOrEmpty(turn.Id));
 
         var row = Assert.Single(await store.ListAsync());
         Assert.Equal(1, row.TurnCount);
-        Assert.Empty(row.BookIds);
+        Assert.Equal(new[] { "b" }, row.BookIds);
+    }
+
+    /// <summary>An empty status and a missing one are one thing in the file, so a clean turn compares equal to
+    /// a clean turn. The live view model writes <c>""</c>; the record folds it to null.</summary>
+    [Fact]
+    public void An_empty_status_is_stored_as_no_status()
+    {
+        var turn = new AiTurnRecord { Status = "" };
+        Assert.Null(turn.Status);
+
+        var json = JsonSerializer.Serialize(turn, AiSessionStore.JsonOptions);
+        Assert.DoesNotContain("status", json);
+
+        var back = JsonSerializer.Deserialize<AiTurnRecord>(
+            """{ "status": "" }""", AiSessionStore.JsonOptions);
+        Assert.Null(back!.Status);
     }
 
     // ---- the list ---------------------------------------------------------------------------------------
@@ -349,6 +498,7 @@ public sealed class AiSessionStoreTests : IDisposable
         // of it either.
         session.Turns.Add(new AiTurnRecord
         {
+            Id = "turn-four",
             Task = AiTask.Grammar,
             Citation = Citation("s0402m.mul.xml", "Mahāvaggapāḷi", "1.2"),
             When = Created.AddMinutes(20),
@@ -532,6 +682,72 @@ public sealed class AiSessionStoreTests : IDisposable
     }
 
     /// <summary>
+    /// A save that fails part way through leaves the session that was there byte-identical, and promotes
+    /// nothing.
+    ///
+    /// <para><b>Fault injection rather than inspection</b>, because the leftover-temp test above would pass an
+    /// implementation with no atomicity at all: it only shows that a stale temp is not trusted. Here the write
+    /// of the temp file itself is made to fail — the temp path is occupied by a directory, which no
+    /// <c>WriteAllText</c> on any platform can write over — after a good session is already on disk. What the
+    /// reader must not lose is the conversation they already had.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_save_that_fails_mid_write_leaves_the_previous_session_untouched()
+    {
+        var store = Store();
+        await store.SaveAsync(Conversation());
+
+        var before = File.ReadAllBytes(PathFor("session-one"));
+
+        // Occupy the temp path with a directory: the write cannot produce the new contents, so nothing can be
+        // promoted over the good file.
+        Directory.CreateDirectory(PathFor("session-one") + ".tmp");
+
+        var doomed = Conversation();
+        doomed.Name = "Should never be written";
+        Assert.False(await store.SaveAsync(doomed));
+
+        Assert.Equal(before, File.ReadAllBytes(PathFor("session-one")));
+        var loaded = await store.LoadAsync("session-one");
+        Assert.Equal("Explain · Mahāvaggapāḷi 1.1", loaded!.Name);
+
+        // And the store is still usable once the obstruction is gone.
+        Directory.Delete(PathFor("session-one") + ".tmp");
+        Assert.True(await store.SaveAsync(doomed));
+    }
+
+    /// <summary>
+    /// A cancelled token is reported, not thrown — and the write lock survives it.
+    ///
+    /// <para>The wiring saves at the end of a turn with the turn's own token, which is the one the reader may
+    /// have just cancelled by pressing Stop. A store whose contract says "reported, never thrown" must not
+    /// answer that with a <c>TaskCanceledException</c>, and must not leave its own lock held: the first cut
+    /// took the lock outside the try and did both.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_cancelled_save_is_reported_rather_than_thrown()
+    {
+        var store = Store();
+        await store.SaveAsync(Conversation());
+        var before = File.ReadAllBytes(PathFor("session-one"));
+
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        var renamed = Conversation();
+        renamed.Name = "Not saved";
+        Assert.False(await store.SaveAsync(renamed, cancelled.Token));
+
+        Assert.Equal(before, File.ReadAllBytes(PathFor("session-one")));
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
+
+        // The lock was released, so the next save still works. Without this the panel would simply stop
+        // persisting for the rest of the session, silently.
+        Assert.True(await store.SaveAsync(renamed));
+        Assert.Equal("Not saved", (await store.LoadAsync("session-one"))!.Name);
+    }
+
+    /// <summary>
     /// An id that would address a path of its own choosing is refused, on every operation.
     ///
     /// <para>Every id reaching the store comes from outside it — a directory listing,
@@ -565,9 +781,12 @@ public sealed class AiSessionStoreTests : IDisposable
     /// suite stays green. This is the test that makes such a change a <b>diff</b>, which is the only form in
     /// which a "forever, no cap" format change can be reviewed.</para>
     ///
-    /// <para><b>Expect it to fail when P1 (#991) lands</b>: adding the replayed conversation to
-    /// <c>SentContext</c> changes what a stored turn writes. That is the mechanism working. Regenerate the
-    /// file from the path the failure message names, and read the diff before accepting it.</para>
+    /// <para><b>#991 will not move it.</b> An earlier version of this comment predicted that landing the
+    /// conversation replay would change the format, because the record stored the live <c>SentContext</c>. A
+    /// review probe showed what that change would actually have been — a leaked <c>"hasHistory": false</c> on
+    /// every stored turn, from the computed getter #991 adds — and the format now owns its own types, so
+    /// nothing on the live side reaches the file. A failure here means someone changed the stored shape:
+    /// regenerate from the path the failure names, and read the diff before accepting it.</para>
     ///
     /// <para>It uses <c>AiSessionStore.JsonOptions</c> rather than a copy: a mirrored copy cannot detect drift
     /// from the original, which is the one thing it most needs to detect. (#787)</para>
@@ -576,6 +795,13 @@ public sealed class AiSessionStoreTests : IDisposable
     public void The_on_disk_format_matches_the_golden_file()
     {
         var session = Conversation("golden-session");
+        session.Compactions.Add(new AiCompactionRecord
+        {
+            When = Created.AddMinutes(30),
+            Summary = "Two earlier turns, about the opening of the Mahāvagga.",
+            SummarisedTurnIds = { "turn-one", "turn-two" },
+        });
+
         var actual = Normalize(JsonSerializer.Serialize(session, AiSessionStore.JsonOptions));
 
         var goldenPath = Path.Combine(
@@ -601,6 +827,8 @@ public sealed class AiSessionStoreTests : IDisposable
         Assert.Equal("Mahāvaggapāḷi", loaded.Turns[0].Citation!.BookName);
         Assert.Equal(0.375, loaded.Turns[0].ReadingPosition!.Fraction);
         Assert.NotNull(loaded.Turns[0].Sent);
+        Assert.Equal(new[] { "turn-one" }, loaded.Turns[1].Sent!.ReplayedTurnIds);
+        Assert.Single(loaded.Compactions);
     }
 
     /// <summary>

--- a/src/CST.Avalonia.Tests/Services/Ai/assistant-session.golden.json
+++ b/src/CST.Avalonia.Tests/Services/Ai/assistant-session.golden.json
@@ -10,6 +10,7 @@
       "task": "Explain",
       "askedLine": "«Explain» — Mahāvaggapāḷi 1.1",
       "answer": "The paragraph opens the Mahāvagga.",
+      "markedAnswer": "The paragraph opens the [[Mahāvagga]].",
       "reasoning": "First, identify the speaker…",
       "citation": {
         "bookId": "s0402m.mul.xml",
@@ -62,7 +63,8 @@
       "task": "Ask",
       "question": "What does bhagavā mean here?",
       "askedLine": "«Question» — Mahāvaggapāḷi 1.1: What does bhagavā mean here?",
-      "answer": "It is an epithet",
+      "answer": "It is an epithet: bhagavā",
+      "markedAnswer": "It is an epithet: [[bhagavā]]",
       "notices": [],
       "isPartialPassage": false,
       "elapsedMs": 63000,

--- a/src/CST.Avalonia.Tests/Services/Ai/assistant-session.golden.json
+++ b/src/CST.Avalonia.Tests/Services/Ai/assistant-session.golden.json
@@ -1,0 +1,91 @@
+{
+  "version": "1.0",
+  "id": "golden-session",
+  "name": "Explain · Mahāvaggapāḷi 1.1",
+  "created": "2026-09-12T10:15:00+00:00",
+  "lastActive": "2026-09-12T10:27:00+00:00",
+  "turns": [
+    {
+      "task": "Explain",
+      "answer": "The paragraph opens the Mahāvagga.",
+      "reasoning": "First, identify the speaker…",
+      "citation": {
+        "bookId": "s0402m.mul.xml",
+        "bookName": "Mahāvaggapāḷi",
+        "normalizedReference": "1.1",
+        "pages": [
+          {
+            "edition": "Vri",
+            "volume": 1,
+            "number": 23
+          }
+        ]
+      },
+      "subject": "tena samayena buddho bhagavā",
+      "notices": [
+        "The word list was not available.",
+        "The apparatus was empty."
+      ],
+      "isPartialPassage": true,
+      "usage": "1,024 in · 512 out",
+      "elapsed": "4.2s",
+      "status": "",
+      "failed": false,
+      "sent": {
+        "fields": [
+          {
+            "name": "Provider",
+            "value": "anthropic"
+          },
+          {
+            "name": "Model",
+            "value": "claude-opus-4-1"
+          }
+        ],
+        "systemPrompt": "You are reading Pāli.",
+        "userContent": "Passage: tena samayena…"
+      },
+      "providerId": "anthropic",
+      "modelId": "claude-opus-4-1",
+      "when": "2026-09-12T10:15:00+00:00",
+      "readingPosition": {
+        "above": "para1",
+        "below": "para2",
+        "fraction": 0.375
+      }
+    },
+    {
+      "task": "Ask",
+      "question": "What does bhagavā mean here?",
+      "answer": "It is an epithet",
+      "notices": [],
+      "isPartialPassage": false,
+      "elapsed": "1m 3s",
+      "status": "The provider closed the connection.",
+      "failed": true,
+      "providerId": "anthropic",
+      "modelId": "claude-opus-4-1",
+      "when": "2026-09-12T10:21:00+00:00"
+    },
+    {
+      "task": "Translate",
+      "answer": "At that time the Blessed One…",
+      "citation": {
+        "bookId": "s0403m.mul.xml",
+        "bookName": "Cūḷavaggapāḷi",
+        "normalizedReference": "2.4",
+        "pages": [
+          {
+            "edition": "Vri",
+            "volume": 1,
+            "number": 23
+          }
+        ]
+      },
+      "notices": [],
+      "isPartialPassage": false,
+      "failed": false,
+      "when": "2026-09-12T10:27:00+00:00"
+    }
+  ]
+}

--- a/src/CST.Avalonia.Tests/Services/Ai/assistant-session.golden.json
+++ b/src/CST.Avalonia.Tests/Services/Ai/assistant-session.golden.json
@@ -6,7 +6,9 @@
   "lastActive": "2026-09-12T10:27:00+00:00",
   "turns": [
     {
+      "id": "turn-one",
       "task": "Explain",
+      "askedLine": "«Explain» — Mahāvaggapāḷi 1.1",
       "answer": "The paragraph opens the Mahāvagga.",
       "reasoning": "First, identify the speaker…",
       "citation": {
@@ -27,9 +29,9 @@
         "The apparatus was empty."
       ],
       "isPartialPassage": true,
-      "usage": "1,024 in · 512 out",
-      "elapsed": "4.2s",
-      "status": "",
+      "inputTokens": 1024,
+      "outputTokens": 512,
+      "elapsedMs": 4200,
       "failed": false,
       "sent": {
         "fields": [
@@ -43,7 +45,8 @@
           }
         ],
         "systemPrompt": "You are reading Pāli.",
-        "userContent": "Passage: tena samayena…"
+        "userContent": "Passage: tena samayena…",
+        "replayedTurnIds": []
       },
       "providerId": "anthropic",
       "modelId": "claude-opus-4-1",
@@ -55,19 +58,30 @@
       }
     },
     {
+      "id": "turn-two",
       "task": "Ask",
       "question": "What does bhagavā mean here?",
+      "askedLine": "«Question» — Mahāvaggapāḷi 1.1: What does bhagavā mean here?",
       "answer": "It is an epithet",
       "notices": [],
       "isPartialPassage": false,
-      "elapsed": "1m 3s",
+      "elapsedMs": 63000,
       "status": "The provider closed the connection.",
       "failed": true,
+      "sent": {
+        "fields": [],
+        "systemPrompt": "You are reading Pāli.",
+        "userContent": "Passage: tena samayena… What does bhagavā mean here?",
+        "replayedTurnIds": [
+          "turn-one"
+        ]
+      },
       "providerId": "anthropic",
       "modelId": "claude-opus-4-1",
       "when": "2026-09-12T10:21:00+00:00"
     },
     {
+      "id": "turn-three",
       "task": "Translate",
       "answer": "At that time the Blessed One…",
       "citation": {
@@ -86,6 +100,16 @@
       "isPartialPassage": false,
       "failed": false,
       "when": "2026-09-12T10:27:00+00:00"
+    }
+  ],
+  "compactions": [
+    {
+      "when": "2026-09-12T10:45:00+00:00",
+      "summary": "Two earlier turns, about the opening of the Mahāvagga.",
+      "summarisedTurnIds": [
+        "turn-one",
+        "turn-two"
+      ]
     }
   ]
 }

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1646,6 +1646,11 @@ public partial class App : Application
         // mode. (#790)
         services.AddSingleton<Services.Ai.IAiModelListingCache>(_ => new Services.Ai.AiModelListingCache());
 
+        // Assistant conversations, one file each under <DataDirectory>/assistant-sessions/. Not in
+        // application-state.json, which keeps only the active session's id — a transcript is a different
+        // weight class from a window rectangle, and everything in that file shares its failure mode. (#849)
+        services.AddSingleton<Services.Ai.IAiSessionStore, Services.Ai.AiSessionStore>();
+
         // The fidelity advisory (#584). Data only — Settings (#585) and the panel (#586) surface it.
         services.AddSingleton<ILemmaReportService, LemmaReportService>();
 

--- a/src/CST.Avalonia/Models/ApplicationState.cs
+++ b/src/CST.Avalonia/Models/ApplicationState.cs
@@ -90,6 +90,23 @@ public class ApplicationState
     /// </summary>
     public List<string> AppliedDataMigrations { get; set; } = new();
 
+    /// <summary>
+    /// The Assistant conversation to reopen on launch, or null if there is none. (#849)
+    ///
+    /// <para><b>[fsnow]</b> chose <i>"Restore the last session silently"</i>, so this is read at startup the
+    /// way open books and reading positions are — no model call, no prompt.</para>
+    ///
+    /// <para><b>An id, not the conversation.</b> The transcripts live one file each under
+    /// <c>&lt;DataDirectory&gt;/assistant-sessions/</c> (<see cref="Services.Ai.IAiSessionStore"/>): this file
+    /// is read synchronously at launch and backed up on a timer, and a session with forty answers in it is a
+    /// different weight class from a window rectangle. Everything sharing this file shares its failure mode,
+    /// and a transcript is the last thing that should be able to cost a reader their window layout.</para>
+    ///
+    /// <para>An id naming a session that has since been deleted is not an error — the store answers null and
+    /// the panel starts empty.</para>
+    /// </summary>
+    public string? ActiveAssistantSessionId { get; set; }
+
     // Application Preferences
     public ApplicationPreferences Preferences { get; set; } = new();
 }

--- a/src/CST.Avalonia/Services/Ai/AiSession.cs
+++ b/src/CST.Avalonia/Services/Ai/AiSession.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using CST.Avalonia.Models;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// One Assistant conversation, as it is kept on disk. (#849)
+///
+/// <para><b>Why a session file rather than a section of <c>application-state.json</c>.</b> That file is read
+/// synchronously at launch, backed up on a timer, and holds window rectangles and file names; a transcript
+/// with forty answers in it is a different weight class and a different failure mode, and everything sharing
+/// that file shares its failure mode. So <see cref="ApplicationState.ActiveAssistantSessionId"/> is the only
+/// thing state keeps — one string — and the conversations live one file each under
+/// <c>&lt;DataDirectory&gt;/assistant-sessions/</c>.</para>
+///
+/// <para><b>[fsnow]</b> on the shape of the collection: <i>"One global list"</i>, not per book, and retention
+/// is <i>"Forever, no cap"</i> — nothing here expires, and deletion is a deliberate per-session act
+/// (<see cref="IAiSessionStore.DeleteAsync"/>). The Claude Code model this is transposed from is
+/// <b>[fsnow]</b>'s own: <i>"Claude Code itself is my model and we should aim for feature parity with CC in
+/// context management, named sessions, session restoration, etc."</i></para>
+///
+/// <para>A mutable class with settable properties rather than a positional record, for two reasons that both
+/// come from how it is used: the wiring PR fills a turn in as it streams (the answer arrives in pieces, usage
+/// and elapsed at the end), and the persisted app-state types next door are written the same way, so the JSON
+/// behaviour is the one this codebase already reasons about.</para>
+/// </summary>
+public sealed class AiSession
+{
+    /// <summary>
+    /// Shape of this file, for the migration that a "forever, no cap" retention rule eventually forces: a
+    /// session written by today's build is expected to be readable years and several formats later, which is
+    /// true of nothing else the app keeps. Same role as <see cref="ApplicationState.Version"/>.
+    /// <b>[suggestion]</b> — nothing reads it yet, and the first thing that needs to will be glad it is there.
+    /// </summary>
+    public string Version { get; set; } = "1.0";
+
+    /// <summary>
+    /// Identity, and also the file name (<c>&lt;id&gt;.json</c>). Constrained to letters, digits, <c>-</c> and
+    /// <c>_</c> — see <see cref="AiSessionStore.IsWellFormedId"/>, which refuses anything else rather than
+    /// letting an id that arrived from a directory listing or from <c>application-state.json</c> address a
+    /// path of its own choosing.
+    /// </summary>
+    public string Id { get; set; } = NewId();
+
+    /// <summary>
+    /// What the reader sees in the session list. <b>[fsnow]</b> chose <i>"Auto from the first turn,
+    /// renamable"</i>, so this is written by the naming rule at the first turn and then by rename — never by a
+    /// model. Empty until named; the store neither invents nor requires a name (naming is P3's, and a store
+    /// that refused an unnamed session would make the first turn's write order significant for no reason).
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>When the conversation was started.</summary>
+    public DateTimeOffset Created { get; set; }
+
+    /// <summary>
+    /// When it was last added to or renamed — the sort key of the session list, newest first, and what
+    /// "restore the last session" resolves against.
+    /// </summary>
+    public DateTimeOffset LastActive { get; set; }
+
+    /// <summary>The turns, oldest first — the order the panel renders and the order history is replayed in.</summary>
+    public List<AiTurnRecord> Turns { get; set; } = new();
+
+    /// <summary>
+    /// Properties a NEWER build wrote that this one does not know, carried through a round-trip. (#883's
+    /// mechanism, applied here.)
+    ///
+    /// <para>The exposure is realer for a session than for app state: a session file is rewritten at the end
+    /// of every turn, so one launch of an older build over a newer build's session strips whatever that build
+    /// added — silently, because an unknown property is not an error to System.Text.Json, it is simply
+    /// dropped. <b>[suggestion]</b>; the cost is one member and it is what makes "forever" survive a reader
+    /// who runs several builds. <see cref="AiTurnRecord.UnknownProperties"/> covers the level where new fields
+    /// will actually land.</para>
+    /// </summary>
+    [JsonExtensionData]
+    public Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }
+
+    /// <summary>A fresh session id. A GUID, like <c>BookWindowState.WindowId</c>: nothing orders sessions by
+    /// file name — <see cref="LastActive"/> does — so an opaque id is all this has to be.</summary>
+    public static string NewId() => Guid.NewGuid().ToString();
+}
+
+/// <summary>
+/// One stored turn: everything the panel shows, so a restored turn renders identically to the live one that
+/// produced it. (#849)
+///
+/// <para>The field list is taken from <c>AiTurnViewModel</c> rather than designed — what is missing from here
+/// is what a reader would find missing from a reopened conversation. Nothing has to be RECOMPUTED to write
+/// one; the turn already carries all of it, with the single exception of <see cref="ReadingPosition"/>, which
+/// the wiring PR captures at the start of a turn.</para>
+///
+/// <para><b>What is deliberately not here:</b> the rendered answer blocks (<c>AnswerMarkup.Parse</c> rebuilds
+/// them from <see cref="Answer"/>, and storing a parse would freeze today's renderer into the file), the
+/// rendered citation strings (the panel builds those from <see cref="Citation"/>, which is the rule that makes
+/// a false citation impossible — chrome is built from bundle data, never parsed out of model output), and
+/// <c>IsRunning</c> (a restored turn is never running).</para>
+/// </summary>
+public sealed class AiTurnRecord
+{
+    /// <summary>Which preset was asked for. Serialized as its NAME — see
+    /// <see cref="AiSessionStore.JsonOptions"/> — because the numbers are positional and these files outlive
+    /// builds that may insert a preset.</summary>
+    public AiTask Task { get; set; }
+
+    /// <summary>The reader's own question, where the preset takes one. Null for the four that do not.</summary>
+    public string? Question { get; set; }
+
+    /// <summary>
+    /// The answer as the model sent it, markup and all — the same string <c>AiTurnViewModel.Answer</c> holds
+    /// and Copy hands over. A partial answer from a failed or stopped turn is stored as it stands: it is on
+    /// screen, so it belongs in the record.
+    /// </summary>
+    public string? Answer { get; set; }
+
+    /// <summary>
+    /// The model thinking aloud, kept segregated exactly as the live turn keeps it. Stored because a turn
+    /// without it does not render identically — the panel offers it collapsed — and <b>never</b> merged into
+    /// <see cref="Answer"/>: half-formed guesses about the text are not what the model is telling the reader.
+    /// (It is also never replayed to a model; that is P1's rule, and this field is not an argument against
+    /// it.)
+    /// </summary>
+    public string? Reasoning { get; set; }
+
+    /// <summary>
+    /// What the answer is about, as the structured reference rather than the rendered line.
+    ///
+    /// <para><b>[fsnow]</b>: <i>"A restored turn should be able to reopen its book and restore the selection,
+    /// as something the reader chooses rather than something that happens on load."</i> That is what makes
+    /// this field required in spirit even where the type allows null: <c>CitationRef</c> carries
+    /// <c>BookId</c>, <c>BookName</c>, <c>NormalizedReference</c> and the page references, which is everything
+    /// "take me back" (P5) needs to reopen the right book at the right paragraph. Storing the rendered string
+    /// instead would leave a restored turn readable and unnavigable.</para>
+    /// </summary>
+    public CitationRef? Citation { get; set; }
+
+    /// <summary>
+    /// The selection summary shown beside the Stop button — display text only. The full selection is in
+    /// <see cref="Sent"/>; this is the short form the panel puts on screen so a wrong subject is obvious.
+    /// </summary>
+    public string? Subject { get; set; }
+
+    /// <summary>
+    /// How the request was ASSEMBLED — a trimmed part, a missing optional asset, a rejected prompt edit.
+    /// Facts about the input rather than failures, and a restored turn that dropped them would overstate how
+    /// complete its answer was.
+    /// </summary>
+    public List<string> Notices { get; set; } = new();
+
+    /// <summary>The model did not see all of the passage. The one caveat that changes how far the answer can
+    /// be trusted, which is why the panel shows it in the open rather than under the notices.</summary>
+    public bool IsPartialPassage { get; set; }
+
+    /// <summary>Tokens as the panel prints them. The display string rather than the numbers, because that is
+    /// what the turn holds — there is no structured usage on the view model to store.</summary>
+    public string? Usage { get; set; }
+
+    /// <summary>How long the turn took, already formatted. Kept for the reason the live turn keeps it: a
+    /// reader deciding whether to ask a slow model another question wants the last one's cost in front of
+    /// them.</summary>
+    public string? Elapsed { get; set; }
+
+    /// <summary>The one line that said what went wrong, when something did. Empty on a clean turn.</summary>
+    public string? Status { get; set; }
+
+    /// <summary>Whether <see cref="Status"/> is a failure rather than progress. They are drawn differently and
+    /// only one of them offers Retry, so storing the line without this flag would restore an error as a
+    /// progress note.</summary>
+    public bool Failed { get; set; }
+
+    /// <summary>
+    /// Everything the turn sent. <b>[fsnow]</b> chose to store the prompt <i>"Yes, in full"</i> — so this is
+    /// the whole of #665's record, both prompt halves and the named fields, not a summary of it.
+    ///
+    /// <para><b>Stored as the type, not field by field.</b> P1 (#991) is adding the replayed conversation to
+    /// <c>SentContext</c>; a record that copied its parts by hand would go on loading and saving without them
+    /// and nothing would fail — the reader would simply find that a restored turn's "Context sent" had lost
+    /// the history. Serializing the type as a whole means that addition arrives here with no change to this
+    /// file. It also makes <c>SentContext</c>'s own shape a persisted format from now on: whatever P1 adds
+    /// must itself round-trip through <see cref="AiSessionStore.JsonOptions"/>, which is why the golden file
+    /// in the test suite covers this member.</para>
+    ///
+    /// <para>It carries no secret. An API key is a header the provider adds, never part of a prompt; what is
+    /// here is corpus text, the reader's own question, and the app's own instructions.</para>
+    /// </summary>
+    public SentContext? Sent { get; set; }
+
+    /// <summary>Which connection answered, and which model — an answer is not attributable without them, and a
+    /// session spanning a model change is the ordinary case rather than a corner of it.</summary>
+    public string? ProviderId { get; set; }
+
+    /// <inheritdoc cref="ProviderId"/>
+    public string? ModelId { get; set; }
+
+    /// <summary>When the turn was asked.</summary>
+    public DateTimeOffset When { get; set; }
+
+    /// <summary>
+    /// Where the reader was reading when they asked. <b>[fsnow]</b>: <i>"The Assistant's memory should carry
+    /// the same scroll context saved elsewhere: two anchors and a fraction between them."</i> — so this is
+    /// #434's <see cref="ReadingPositionToken"/>, the representation <c>ApplicationState</c> already persists
+    /// per book, not a pixel offset.
+    ///
+    /// <para>It is not redundant with <see cref="Citation"/>: the citation is where the answer POINTS, this is
+    /// where the reader was STANDING. And a stored turn is exactly the case a raw offset cannot survive —
+    /// everything that invalidates one (font face or size, zoom, script, window size, floating the pane) is
+    /// something a reader does between sessions, while an anchor bracket is re-interpolated at restore.</para>
+    ///
+    /// <para>Null where it was not captured: reading positions come from the WebView, which can be unready,
+    /// and a turn is worth keeping without one. Capture is the wiring PR's job — nothing in this store fills
+    /// it in.</para>
+    /// </summary>
+    public ReadingPositionToken? ReadingPosition { get; set; }
+
+    /// <inheritdoc cref="AiSession.UnknownProperties"/>
+    [JsonExtensionData]
+    public Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }
+}
+
+/// <summary>
+/// One row of the session list: enough to choose a conversation without reading it. (#849 §3.3)
+///
+/// <para>Separate from <see cref="AiSession"/> because listing must not mean keeping — the list is drawn from
+/// every session file on disk, forever, and a reader with two hundred conversations should not have two
+/// hundred transcripts in memory to pick one. The store does read the files to build these (there is no index
+/// to go stale, which is the right trade while a session list is tens of files), but only these leave it.</para>
+/// </summary>
+/// <param name="BookIds">The distinct books this conversation's citations name, in the order they first
+/// appear. What the list row shows instead of the conversation's text — a reader recognises "the one about
+/// Mahāvagga" long before they recognise a name they never typed.</param>
+public sealed record AiSessionSummary(
+    string Id,
+    string Name,
+    DateTimeOffset Created,
+    DateTimeOffset LastActive,
+    int TurnCount,
+    IReadOnlyList<string> BookIds);
+
+/// <summary>
+/// A session file that could not be read, and where it was kept instead. (#849)
+///
+/// <para>Reported rather than thrown: an unreadable transcript must not be able to stop the panel from
+/// opening, and it must not be quietly deleted by the next save either. Both halves of that are the
+/// <c>application-state.unreadable-*</c> pattern (#877), which exists because the alternative — the next save
+/// writing over the only copy — is how a reader loses a session with no way back even by hand.</para>
+/// </summary>
+/// <param name="Id">The session the file claimed to be.</param>
+/// <param name="KeptPath">Where the unreadable file now is. Nothing in it was deleted.</param>
+/// <param name="Error">Why it could not be read. For the log, not for the reader.</param>
+public sealed record AiSessionUnreadable(string Id, string KeptPath, string Error);

--- a/src/CST.Avalonia/Services/Ai/AiSession.cs
+++ b/src/CST.Avalonia/Services/Ai/AiSession.cs
@@ -174,11 +174,35 @@ public sealed class AiTurnRecord
     public string? Answer { get; set; }
 
     /// <summary>
+    /// The same answer as the model wrote it, <c>[[…]]</c> Pāli markers and all. (#991)
+    ///
+    /// <para><b>Why both halves are stored.</b> <see cref="Answer"/> is the stripped form, which is what the
+    /// panel renders; this is the marked form, which is what a later turn replays TO THE MODEL. The system
+    /// prompt tells the model to wrap every Pāli span in those markers, so replaying the stripped form shows
+    /// it a transcript of its own answers disobeying that instruction — the kind of thing a model imitates.
+    /// Keeping only one half would decide, for every session reloaded from disk, either that the transcript
+    /// renders with markers in it or that the model is fed marker-free examples of its own writing; a restored
+    /// conversation has to be able to do both things the live one does.</para>
+    ///
+    /// <para>Unbalanced markers are kept as written, as the live turn keeps them: <c>PaliQuoteFilter</c> strips
+    /// those from the display, rightly, and what the model is shown of its own output should still be what it
+    /// produced.</para>
+    ///
+    /// <para>Null on a turn that produced no text, and on any session written before this field existed —
+    /// where the restore path has only the stripped form to replay, which is the pre-#991 behaviour rather
+    /// than a fault.</para>
+    /// </summary>
+    public string? MarkedAnswer { get; set; }
+
+    /// <summary>
     /// The model thinking aloud, kept segregated exactly as the live turn keeps it. Stored because a turn
     /// without it does not render identically — the panel offers it collapsed — and <b>never</b> merged into
     /// <see cref="Answer"/>: half-formed guesses about the text are not what the model is telling the reader.
-    /// (It is also never replayed to a model; that is #991's rule, and this field is not an argument against
-    /// it.)
+    ///
+    /// <para><b>Stored, never replayed.</b> Unlike <see cref="MarkedAnswer"/>, which exists precisely to be
+    /// replayed, reasoning is kept only so a reopened turn shows what the live one showed. It is not part of
+    /// what a later turn sends: the segregation that keeps it out of the answer is the same rule that keeps it
+    /// out of the conversation (#991).</para>
     /// </summary>
     public string? Reasoning { get; set; }
 

--- a/src/CST.Avalonia/Services/Ai/AiSession.cs
+++ b/src/CST.Avalonia/Services/Ai/AiSession.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using CST.Avalonia.Models;
+using CST.Navigation;
 
 namespace CST.Avalonia.Services.Ai;
 
@@ -21,10 +23,18 @@ namespace CST.Avalonia.Services.Ai;
 /// <b>[fsnow]</b>'s own: <i>"Claude Code itself is my model and we should aim for feature parity with CC in
 /// context management, named sessions, session restoration, etc."</i></para>
 ///
-/// <para>A mutable class with settable properties rather than a positional record, for two reasons that both
-/// come from how it is used: the wiring PR fills a turn in as it streams (the answer arrives in pieces, usage
-/// and elapsed at the end), and the persisted app-state types next door are written the same way, so the JSON
-/// behaviour is the one this codebase already reasons about.</para>
+/// <para><b>Every type in this file is a STORED type, owned by the format rather than shared with the live
+/// pipeline.</b> The first draft stored the live <c>SentContext</c> and <c>CitationRef</c> directly, and a
+/// review probe showed what that costs: those are positional records with no extension data, so a field a
+/// newer build added inside one was silently dropped the first time an older build rewrote the file — the
+/// opposite of what the extension data on the outer types promises — and a computed <c>=&gt;</c> property on
+/// such a record (#991 adds <c>SentContext.HasHistory</c>) is serialized like any other, freezing a derived
+/// boolean into a format meant to last. Mapping between the live types and these is the wiring layer's job,
+/// and it is the price of being able to change either side without changing the other.</para>
+///
+/// <para>Mutable classes with settable properties rather than positional records, for three reasons that all
+/// come from how they are used: the wiring PR fills a turn in as it streams, the persisted app-state types
+/// next door are written the same way, and <see cref="JsonExtensionData"/> wants a settable property.</para>
 /// </summary>
 public sealed class AiSession
 {
@@ -65,21 +75,40 @@ public sealed class AiSession
     public List<AiTurnRecord> Turns { get; set; } = new();
 
     /// <summary>
+    /// Summaries that stand in for older turns in what the model is SENT. Empty until P4 exists.
+    ///
+    /// <para>A slot rather than a feature: compaction (<b>[fsnow]</b>: <i>"Manual and auto at a fraction of
+    /// context length"</i>, <i>"Last 4 turns"</i> verbatim) replaces a run of turns in the request with one
+    /// summary while the transcript on screen keeps every turn. That summary is model output that cost a call
+    /// and cannot be recomputed from the file, so it belongs in the file — and it belongs at the session level
+    /// rather than on a turn, because it is about a span of them.</para>
+    ///
+    /// <para>Here now because adding it later would mean a format change to every session on disk; empty now
+    /// because nothing writes it. <b>[suggestion]</b>.</para>
+    /// </summary>
+    public List<AiCompactionRecord> Compactions { get; set; } = new();
+
+    /// <summary>
     /// Properties a NEWER build wrote that this one does not know, carried through a round-trip. (#883's
-    /// mechanism, applied here.)
+    /// mechanism.)
     ///
     /// <para>The exposure is realer for a session than for app state: a session file is rewritten at the end
     /// of every turn, so one launch of an older build over a newer build's session strips whatever that build
     /// added — silently, because an unknown property is not an error to System.Text.Json, it is simply
     /// dropped. <b>[suggestion]</b>; the cost is one member and it is what makes "forever" survive a reader
-    /// who runs several builds. <see cref="AiTurnRecord.UnknownProperties"/> covers the level where new fields
-    /// will actually land.</para>
+    /// who runs several builds.</para>
+    ///
+    /// <para><b>Extension data is per-object and covers only its own level</b> — which is why every stored
+    /// type in this file carries one, down to a page reference and a named field. A review probe demonstrated
+    /// the failure it prevents: with extension data only on the session and the turn, a newer build's field
+    /// inside <c>sent</c> was dropped on the first rewrite while the outer levels round-tripped perfectly.</para>
     /// </summary>
     [JsonExtensionData]
-    public Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }
+    public Dictionary<string, JsonElement>? UnknownProperties { get; set; }
 
-    /// <summary>A fresh session id. A GUID, like <c>BookWindowState.WindowId</c>: nothing orders sessions by
-    /// file name — <see cref="LastActive"/> does — so an opaque id is all this has to be.</summary>
+    /// <summary>A fresh id, for a session or a turn. A GUID, like <c>BookWindowState.WindowId</c>: nothing
+    /// orders sessions by file name — <see cref="LastActive"/> does — so an opaque id is all this has to
+    /// be.</summary>
     public static string NewId() => Guid.NewGuid().ToString();
 }
 
@@ -88,9 +117,18 @@ public sealed class AiSession
 /// produced it. (#849)
 ///
 /// <para>The field list is taken from <c>AiTurnViewModel</c> rather than designed — what is missing from here
-/// is what a reader would find missing from a reopened conversation. Nothing has to be RECOMPUTED to write
-/// one; the turn already carries all of it, with the single exception of <see cref="ReadingPosition"/>, which
-/// the wiring PR captures at the start of a turn.</para>
+/// is what a reader would find missing from a reopened conversation. What is <b>not</b> taken from it is the
+/// display formatting: usage and elapsed are stored as numbers (see <see cref="InputTokens"/>,
+/// <see cref="ElapsedMs"/>), because the view model holds them already run through <c>FormatUsage</c> and
+/// <c>FormatElapsed</c> and storing those strings would freeze today's wording — and today's culture's digit
+/// grouping — into the file.</para>
+///
+/// <para><b>What the wiring PR has to carry that the view model does not hold today:</b> the
+/// <c>AiUsageReport</c> from the <c>Usage</c> event (<c>Handle</c> formats it and drops it), the
+/// <c>Stopwatch</c>'s own value, the structured <c>CitationRef</c> from the <c>Started</c> event (the view
+/// model keeps only the rendered lines), and the provider and model ids — which are on neither
+/// <c>AiTurnContext</c> nor the view model, so carrying them needs an orchestrator change rather than a
+/// read from the panel.</para>
 ///
 /// <para><b>What is deliberately not here:</b> the rendered answer blocks (<c>AnswerMarkup.Parse</c> rebuilds
 /// them from <see cref="Answer"/>, and storing a parse would freeze today's renderer into the file), the
@@ -100,6 +138,13 @@ public sealed class AiSession
 /// </summary>
 public sealed class AiTurnRecord
 {
+    /// <summary>
+    /// Identity within the session, so other records can point at this turn instead of copying it — see
+    /// <see cref="AiSentRecord.ReplayedTurnIds"/> and <see cref="AiCompactionRecord.SummarisedTurnIds"/>.
+    /// Generated the way a session id is; never a file name, so nothing validates it.
+    /// </summary>
+    public string Id { get; set; } = AiSession.NewId();
+
     /// <summary>Which preset was asked for. Serialized as its NAME — see
     /// <see cref="AiSessionStore.JsonOptions"/> — because the numbers are positional and these files outlive
     /// builds that may insert a preset.</summary>
@@ -107,6 +152,19 @@ public sealed class AiTurnRecord
 
     /// <summary>The reader's own question, where the preset takes one. Null for the four that do not.</summary>
     public string? Question { get; set; }
+
+    /// <summary>
+    /// The question side of this turn as it is replayed to a model — the panel's
+    /// <c>DescribeAsked</c> output: preset label, citation line, and the reader's words where there were any.
+    /// (#991)
+    ///
+    /// <para><b>Stored even though it is derivable</b>, which is the opposite of the rule the rest of this
+    /// record follows. The reason is that it is derivable from <i>today's</i> wording: a later change to
+    /// <c>DescribeAsked</c> — a different dash, the preset label dropped — would make every reconstructed
+    /// history differ from what was actually sent, and a record of what a model saw that quietly re-renders
+    /// itself is not a record. A few dozen bytes a turn buys that.</para>
+    /// </summary>
+    public string? AskedLine { get; set; }
 
     /// <summary>
     /// The answer as the model sent it, markup and all — the same string <c>AiTurnViewModel.Answer</c> holds
@@ -119,22 +177,22 @@ public sealed class AiTurnRecord
     /// The model thinking aloud, kept segregated exactly as the live turn keeps it. Stored because a turn
     /// without it does not render identically — the panel offers it collapsed — and <b>never</b> merged into
     /// <see cref="Answer"/>: half-formed guesses about the text are not what the model is telling the reader.
-    /// (It is also never replayed to a model; that is P1's rule, and this field is not an argument against
+    /// (It is also never replayed to a model; that is #991's rule, and this field is not an argument against
     /// it.)
     /// </summary>
     public string? Reasoning { get; set; }
 
     /// <summary>
-    /// What the answer is about, as the structured reference rather than the rendered line.
+    /// What the answer is about.
     ///
     /// <para><b>[fsnow]</b>: <i>"A restored turn should be able to reopen its book and restore the selection,
     /// as something the reader chooses rather than something that happens on load."</i> That is what makes
-    /// this field required in spirit even where the type allows null: <c>CitationRef</c> carries
-    /// <c>BookId</c>, <c>BookName</c>, <c>NormalizedReference</c> and the page references, which is everything
-    /// "take me back" (P5) needs to reopen the right book at the right paragraph. Storing the rendered string
-    /// instead would leave a restored turn readable and unnavigable.</para>
+    /// this field required in spirit even where the type allows null: it carries the book, the reference and
+    /// the pages, which is everything "take me back" (P5) needs to reopen the right book at the right
+    /// paragraph. Storing the rendered line instead would leave a restored turn readable and
+    /// unnavigable.</para>
     /// </summary>
-    public CitationRef? Citation { get; set; }
+    public AiCitationRecord? Citation { get; set; }
 
     /// <summary>
     /// The selection summary shown beside the Stop button — display text only. The full selection is in
@@ -153,17 +211,41 @@ public sealed class AiTurnRecord
     /// be trusted, which is why the panel shows it in the open rather than under the notices.</summary>
     public bool IsPartialPassage { get; set; }
 
-    /// <summary>Tokens as the panel prints them. The display string rather than the numbers, because that is
-    /// what the turn holds — there is no structured usage on the view model to store.</summary>
-    public string? Usage { get; set; }
+    /// <summary>
+    /// Tokens as the provider reported them, null where it reported that half not at all — the two numbers
+    /// from <c>AiUsageReport</c> rather than the line the panel prints from them.
+    ///
+    /// <para>The display string would have frozen both today's wording and today's <b>culture</b> into the
+    /// file: <c>FormatUsage</c> runs the counts through <c>:N0</c>, so a session written on a de-DE machine
+    /// says <c>1.024</c> and one written beside it says <c>1,024</c> for the same number. Numbers also let a
+    /// future "what has this conversation cost" add up, which strings never could.</para>
+    /// </summary>
+    public int? InputTokens { get; set; }
 
-    /// <summary>How long the turn took, already formatted. Kept for the reason the live turn keeps it: a
-    /// reader deciding whether to ask a slow model another question wants the last one's cost in front of
-    /// them.</summary>
-    public string? Elapsed { get; set; }
+    /// <inheritdoc cref="InputTokens"/>
+    public int? OutputTokens { get; set; }
 
-    /// <summary>The one line that said what went wrong, when something did. Empty on a clean turn.</summary>
-    public string? Status { get; set; }
+    /// <summary>
+    /// How long the turn took, in milliseconds. Kept for the reason the live turn keeps it: a reader deciding
+    /// whether to ask a slow model another question wants the last one's cost in front of them. A duration
+    /// rather than <c>FormatElapsed</c>'s <c>"4.2s"</c>, for the same reason as the token counts — and because
+    /// <c>"1m 3s"</c> cannot be compared, summed, or reformatted.
+    /// </summary>
+    public long? ElapsedMs { get; set; }
+
+    /// <summary>
+    /// The one line that said what went wrong, when something did. <b>Null on a clean turn</b> — the setter
+    /// folds an empty string to null, so the file has one encoding for "nothing to say" rather than two that
+    /// mean the same thing and compare unequal. (The live view model uses <c>""</c>; the mapping is the wiring
+    /// layer's, and this setter makes it impossible to get wrong.)
+    /// </summary>
+    public string? Status
+    {
+        get => _status;
+        set => _status = string.IsNullOrEmpty(value) ? null : value;
+    }
+
+    private string? _status;
 
     /// <summary>Whether <see cref="Status"/> is a failure rather than progress. They are drawn differently and
     /// only one of them offers Retry, so storing the line without this flag would restore an error as a
@@ -174,18 +256,15 @@ public sealed class AiTurnRecord
     /// Everything the turn sent. <b>[fsnow]</b> chose to store the prompt <i>"Yes, in full"</i> — so this is
     /// the whole of #665's record, both prompt halves and the named fields, not a summary of it.
     ///
-    /// <para><b>Stored as the type, not field by field.</b> P1 (#991) is adding the replayed conversation to
-    /// <c>SentContext</c>; a record that copied its parts by hand would go on loading and saving without them
-    /// and nothing would fail — the reader would simply find that a restored turn's "Context sent" had lost
-    /// the history. Serializing the type as a whole means that addition arrives here with no change to this
-    /// file. It also makes <c>SentContext</c>'s own shape a persisted format from now on: whatever P1 adds
-    /// must itself round-trip through <see cref="AiSessionStore.JsonOptions"/>, which is why the golden file
-    /// in the test suite covers this member.</para>
+    /// <para>A stored type rather than the live <c>SentContext</c>. See the note on <see cref="AiSession"/>:
+    /// the live one is a positional record with no extension data and, since #991, a computed
+    /// <c>HasHistory</c> property — so storing it directly both leaked a derived boolean into the format and
+    /// dropped any newer build's nested field on the first rewrite. Mapping the two is the wiring layer's job.</para>
     ///
     /// <para>It carries no secret. An API key is a header the provider adds, never part of a prompt; what is
     /// here is corpus text, the reader's own question, and the app's own instructions.</para>
     /// </summary>
-    public SentContext? Sent { get; set; }
+    public AiSentRecord? Sent { get; set; }
 
     /// <summary>Which connection answered, and which model — an answer is not attributable without them, and a
     /// session spanning a model change is the ordinary case rather than a corner of it.</summary>
@@ -200,8 +279,11 @@ public sealed class AiTurnRecord
     /// <summary>
     /// Where the reader was reading when they asked. <b>[fsnow]</b>: <i>"The Assistant's memory should carry
     /// the same scroll context saved elsewhere: two anchors and a fraction between them."</i> — so this is
-    /// #434's <see cref="ReadingPositionToken"/>, the representation <c>ApplicationState</c> already persists
-    /// per book, not a pixel offset.
+    /// #434's <see cref="ReadingPositionToken"/> itself, the one type <b>shared</b> with the app rather than
+    /// restated here, because it is already a persisted type in exactly this shape (<c>ApplicationState</c>
+    /// keeps one per book), it is already a mutable class rather than a positional record, and its three
+    /// fields are a closed set with <c>ReadingPositionMath</c> owning their interpretation. Sharing the app's
+    /// persisted representation is the whole of what he asked for.
     ///
     /// <para>It is not redundant with <see cref="Citation"/>: the citation is where the answer POINTS, this is
     /// where the reader was STANDING. And a stored turn is exactly the case a raw offset cannot survive —
@@ -216,7 +298,128 @@ public sealed class AiTurnRecord
 
     /// <inheritdoc cref="AiSession.UnknownProperties"/>
     [JsonExtensionData]
-    public Dictionary<string, System.Text.Json.JsonElement>? UnknownProperties { get; set; }
+    public Dictionary<string, JsonElement>? UnknownProperties { get; set; }
+}
+
+/// <summary>
+/// What a turn sent, stored. The prompt in full (<b>[fsnow]</b>: <i>"Yes, in full"</i>) — with one exception,
+/// and it is the point of this type.
+///
+/// <para><b>The replayed conversation is stored by reference, not by value.</b> #991 replays every earlier
+/// turn that has an answer, so a by-value copy puts every earlier answer inside every later turn: turn 30 of a
+/// 30-turn conversation would carry 29 answers, and the session file would carry 435 copies of them. All of it
+/// is reconstructible, because a written turn never changes — the ids here plus each referenced turn's
+/// <see cref="AiTurnRecord.AskedLine"/> and <see cref="AiTurnRecord.Answer"/> rebuild
+/// <c>SentContext.History</c> exactly, which is the restore path's job.</para>
+///
+/// <para>What is NOT reconstructible is kept: <see cref="SystemPrompt"/> and <see cref="UserContent"/> are the
+/// prompt this turn actually sent, including the passage as it read at the time, and a corrected corpus or an
+/// edited template would make a re-gathered version differ.</para>
+/// </summary>
+public sealed class AiSentRecord
+{
+    /// <summary>Named values in display order — provider, model, task, language, book, reference, pages, the
+    /// estimated token count, and what each gathered part contributed.</summary>
+    public List<AiSentFieldRecord> Fields { get; set; } = new();
+
+    /// <summary>The shared system prompt as it was sent.</summary>
+    public string SystemPrompt { get; set; } = string.Empty;
+
+    /// <summary>The final user message: context blocks and the preset instruction, as they were sent.</summary>
+    public string UserContent { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The turns replayed ahead of this one, oldest first, as <see cref="AiTurnRecord.Id"/> values. Empty for
+    /// a one-shot turn, which is what every turn was before #991.
+    ///
+    /// <para>An id that names no turn in the session is not an error — a turn deleted from a session by hand
+    /// leaves one. The restore path skips what it cannot resolve; the alternative, refusing the whole
+    /// conversation over a dangling reference, is the failure this layer exists to avoid.</para>
+    /// </summary>
+    public List<string> ReplayedTurnIds { get; set; } = new();
+
+    /// <inheritdoc cref="AiSession.UnknownProperties"/>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? UnknownProperties { get; set; }
+}
+
+/// <summary>One named value in <see cref="AiSentRecord.Fields"/>.</summary>
+public sealed class AiSentFieldRecord
+{
+    public string Name { get; set; } = string.Empty;
+
+    public string Value { get; set; } = string.Empty;
+
+    /// <inheritdoc cref="AiSession.UnknownProperties"/>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? UnknownProperties { get; set; }
+}
+
+/// <summary>
+/// Everything needed to cite the passage a turn was about, and to go back to it — the stored form of
+/// <c>CitationRef</c>.
+///
+/// <para>Built by the app from bundle data and never parsed back out of model output, which is what makes it
+/// impossible for a garbled answer to produce a false citation on screen. That rule is why this must be the
+/// structured record rather than the line the panel draws from it.</para>
+/// </summary>
+public sealed class AiCitationRecord
+{
+    /// <summary>The open book's file name, as <c>Book.FileName</c> spells it — what "take me back" opens.</summary>
+    public string BookId { get; set; } = string.Empty;
+
+    public string BookName { get; set; } = string.Empty;
+
+    /// <summary>Where in the book, normalized — the paragraph "take me back" goes to.</summary>
+    public string NormalizedReference { get; set; } = string.Empty;
+
+    /// <summary>The print pages the window touched, in whichever editions it names. May be empty; a window
+    /// outside the mūla texts often has no page apparatus at all.</summary>
+    public List<AiPageRecord> Pages { get; set; } = new();
+
+    /// <inheritdoc cref="AiSession.UnknownProperties"/>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? UnknownProperties { get; set; }
+}
+
+/// <summary>One page reference in one edition's numbering — the stored form of <c>SnippetPageRef</c>.</summary>
+public sealed class AiPageRecord
+{
+    /// <summary>Serialized as its name: <c>PageEdition</c> is positional and <c>Vri</c> is its zero.</summary>
+    public PageEdition Edition { get; set; }
+
+    public int Volume { get; set; }
+
+    public int Number { get; set; }
+
+    /// <inheritdoc cref="AiSession.UnknownProperties"/>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? UnknownProperties { get; set; }
+}
+
+/// <summary>
+/// One compaction: a run of turns replaced, in what the model is sent, by a summary of them. Written by P4;
+/// nothing writes it yet.
+///
+/// <para>The summary is model output that cost a call and cannot be recomputed from the turns it replaced —
+/// the same model may not be configured tomorrow, and a re-summary would differ — so it is stored rather than
+/// derived. The transcript on screen keeps every turn regardless: compaction changes what is <b>sent</b>, not
+/// what is <b>shown</b>.</para>
+/// </summary>
+public sealed class AiCompactionRecord
+{
+    /// <summary>When the summary was made.</summary>
+    public DateTimeOffset When { get; set; }
+
+    /// <summary>The summary itself, as the model wrote it.</summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>The turns it stands in for, as <see cref="AiTurnRecord.Id"/> values, oldest first.</summary>
+    public List<string> SummarisedTurnIds { get; set; } = new();
+
+    /// <inheritdoc cref="AiSession.UnknownProperties"/>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? UnknownProperties { get; set; }
 }
 
 /// <summary>

--- a/src/CST.Avalonia/Services/Ai/AiSessionStore.cs
+++ b/src/CST.Avalonia/Services/Ai/AiSessionStore.cs
@@ -258,17 +258,7 @@ public sealed class AiSessionStore : IAiSessionStore
             // behaviour that makes that work rather than producing a session that saves itself elsewhere.
             session.Id = id;
 
-            // A property initializer does NOT survive an explicit null in the file: `"turns": null` sets the
-            // member to null, initializer and all. Everything downstream — this store's own summary, and the
-            // panel rebuilding the transcript — then meets a null collection where the type promises one, and
-            // a NullReferenceException out of a listing is precisely the "cannot open the panel" failure the
-            // rest of this class goes to lengths to avoid. Nothing this build writes produces such a file; a
-            // hand-edit or a truncating tool does.
-            session.Name ??= string.Empty;
-            session.Turns ??= new List<AiTurnRecord>();
-            session.Turns.RemoveAll(t => t is null);
-            foreach (var turn in session.Turns)
-                turn.Notices ??= new List<string>();
+            Normalize(session);
 
             return session;
         }
@@ -280,6 +270,70 @@ public sealed class AiSessionStore : IAiSessionStore
         {
             PreserveUnreadable(id, path, ex.Message);
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Make a loaded session safe to hand out: no null collection where the type promises one, and no null
+    /// element inside one.
+    ///
+    /// <para><b>A property initializer does not survive an explicit null in the file.</b> <c>"turns": null</c>
+    /// sets the member to null, initializer and all, and <c>[ null ]</c> puts a null in a list of a
+    /// non-nullable type. Everything downstream then meets what the type says cannot happen — this store's own
+    /// summary, the panel rebuilding the transcript, <c>Describe(citation)</c> iterating the pages — and a
+    /// <c>NullReferenceException</c> out of a listing is precisely the "the panel will not open" failure the
+    /// rest of this class goes to lengths to avoid.</para>
+    ///
+    /// <para>Nothing this build writes produces such a file. A hand-edit does, and a hand-edited session is a
+    /// thing a reader may well try once the format is documented.</para>
+    /// </summary>
+    private static void Normalize(AiSession session)
+    {
+        session.Name ??= string.Empty;
+        session.Version ??= string.Empty;
+
+        session.Turns ??= new List<AiTurnRecord>();
+        session.Turns.RemoveAll(t => t is null);
+
+        session.Compactions ??= new List<AiCompactionRecord>();
+        session.Compactions.RemoveAll(c => c is null);
+        foreach (var compaction in session.Compactions)
+        {
+            compaction.Summary ??= string.Empty;
+            compaction.SummarisedTurnIds ??= new List<string>();
+            compaction.SummarisedTurnIds.RemoveAll(id => id is null);
+        }
+
+        foreach (var turn in session.Turns)
+        {
+            turn.Id ??= AiSession.NewId();
+            turn.Notices ??= new List<string>();
+            turn.Notices.RemoveAll(n => n is null);
+
+            if (turn.Citation is { } citation)
+            {
+                citation.BookId ??= string.Empty;
+                citation.BookName ??= string.Empty;
+                citation.NormalizedReference ??= string.Empty;
+                citation.Pages ??= new List<AiPageRecord>();
+                citation.Pages.RemoveAll(p => p is null);
+            }
+
+            if (turn.Sent is { } sent)
+            {
+                sent.SystemPrompt ??= string.Empty;
+                sent.UserContent ??= string.Empty;
+                sent.Fields ??= new List<AiSentFieldRecord>();
+                sent.Fields.RemoveAll(f => f is null);
+                foreach (var field in sent.Fields)
+                {
+                    field.Name ??= string.Empty;
+                    field.Value ??= string.Empty;
+                }
+
+                sent.ReplayedTurnIds ??= new List<string>();
+                sent.ReplayedTurnIds.RemoveAll(id => id is null);
+            }
         }
     }
 
@@ -345,9 +399,18 @@ public sealed class AiSessionStore : IAiSessionStore
         var path = PathFor(session.Id);
         var temp = path + ".tmp";
 
-        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // The wait is INSIDE the try, so an already-cancelled token is reported like any other failure rather
+        // than thrown at a caller this contract told not to expect throws. The wiring saves at the end of a
+        // turn with the turn's own token — the one the reader may have just cancelled by pressing Stop — so
+        // "the reader stopped the turn" would otherwise arrive as an exception out of the save that was
+        // supposed to keep what had streamed. (Caught by a review probe on the first cut, which threw
+        // TaskCanceledException here.)
+        var acquired = false;
         try
         {
+            await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            acquired = true;
+
             Directory.CreateDirectory(_directory);
 
             await File.WriteAllTextAsync(temp, json, cancellationToken).ConfigureAwait(false);
@@ -381,7 +444,10 @@ public sealed class AiSessionStore : IAiSessionStore
         }
         finally
         {
-            _writeLock.Release();
+            // Only if we took it. Releasing a semaphore we never acquired — which is what an unconditional
+            // release does when the wait itself was cancelled — hands the next writer a lock it did not wait
+            // for, and the count never comes back.
+            if (acquired) _writeLock.Release();
         }
     }
 

--- a/src/CST.Avalonia/Services/Ai/AiSessionStore.cs
+++ b/src/CST.Avalonia/Services/Ai/AiSessionStore.cs
@@ -1,0 +1,441 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Constants;
+using Microsoft.Extensions.Logging;
+
+namespace CST.Avalonia.Services.Ai;
+
+/// <summary>
+/// Reads and writes Assistant conversations, one file each. (#849 §3.2)
+///
+/// <para><b>What it is not.</b> No timer, no backup directory, no retention sweep. The caller writes a session
+/// when a turn ends, which is the Claude Code guarantee transposed — a crash loses the turn in flight and
+/// nothing else — and <b>[fsnow]</b> chose retention <i>"Forever, no cap"</i>, so there is nothing for a sweep
+/// to do. Deletion is a reader's act on one session, confirmed in the UI (<b>[fsnow]</b>: <i>"Yes, with
+/// confirmation"</i>); this layer provides the delete, not the question.</para>
+///
+/// <para><b>Failures are reported, never thrown.</b> A transcript that cannot be read or written must not be
+/// able to stop the Assistant panel from opening. So <see cref="LoadAsync"/> answers null and keeps the bad
+/// file, <see cref="SaveAsync"/> answers false, and <see cref="Unreadable"/> is how the panel learns enough to
+/// say so on screen.</para>
+/// </summary>
+public interface IAiSessionStore
+{
+    /// <summary>
+    /// One conversation, or null when there is no such file — and also null when the file could not be read,
+    /// in which case it has been moved aside and <see cref="Unreadable"/> has fired. Those two cases are
+    /// deliberately one return value and two reports: a caller restoring the last session does the same thing
+    /// either way (start empty), while a caller that wants to TELL the reader has the event.
+    /// </summary>
+    Task<AiSession?> LoadAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Write the whole session. False when nothing was written — the caller decides whether that is worth
+    /// saying; it must not be worth failing a turn over.
+    ///
+    /// <para>The whole file, not an append. A transcript is rewritten at the end of each turn because the turn
+    /// that just ended is not the only thing that changed about it — <c>LastActive</c> moved, the name may
+    /// have been set from the first turn — and because a partially appended JSON array is unreadable in a way
+    /// a whole-file replace can never be.</para>
+    /// </summary>
+    Task<bool> SaveAsync(AiSession session, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Every readable session on disk as a list row, newest-active first. Unreadable files are kept aside and
+    /// reported through <see cref="Unreadable"/>; they do not appear and do not fail the listing, because one
+    /// broken transcript must not cost the reader the list of the other ninety-nine.
+    /// </summary>
+    Task<IReadOnlyList<AiSessionSummary>> ListAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Remove one conversation. False when there was no such file — <b>not an error</b>: the id can only have
+    /// come from a list the reader was looking at or from <c>ActiveAssistantSessionId</c>, and both can name a
+    /// session that has since gone (a second window, a hand-deleted file). Treating that as a failure would
+    /// mean an error dialog for work already done.
+    /// </summary>
+    Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// A session file could not be read and has been kept. Subscribe before loading or listing.
+    ///
+    /// <para>An event rather than a return value because both <see cref="LoadAsync"/> and
+    /// <see cref="ListAsync"/> can hit it, and in the listing case there may be several while the call still
+    /// has to succeed. The panel's notice ("that conversation could not be read; it has been kept at …") is
+    /// the point of it — the log alone leaves the reader with an empty panel and no explanation.</para>
+    /// </summary>
+    event Action<AiSessionUnreadable>? Unreadable;
+}
+
+/// <inheritdoc cref="IAiSessionStore"/>
+public sealed class AiSessionStore : IAiSessionStore
+{
+    /// <summary>The directory name under <see cref="AppConstants.DataDirectory"/>. One place, so the store and
+    /// anything that later reports on the data directory cannot diverge.</summary>
+    public const string DirectoryName = "assistant-sessions";
+
+    /// <summary>
+    /// How sessions are read and written. <b>Shared rather than mirrored</b> — the tests use THIS property, not
+    /// a copy of it, because a copy cannot detect drift from the original, which is the one thing it most needs
+    /// to detect: change the naming policy or drop the enum converter and every session file on disk stops
+    /// loading while a mirroring suite stays green, since fixture and copy moved together. (#787's lesson,
+    /// stated on <c>ApplicationStateService.JsonOptions</c>.)
+    ///
+    /// <para><b>Two deliberate differences from that one.</b></para>
+    ///
+    /// <para><see cref="JsonSerializerDefaults"/>-style <c>WhenWritingDefault</c> is NOT used. App state uses
+    /// it and pays for it three times over: <c>SearchDialogState</c>, the #224 display bools and #323's
+    /// <c>BookScript</c> all carry force-serialize attributes to undo it, because a written-out <c>false</c> or
+    /// a zero-valued enum is exactly what must survive when the property's initializer is not the type default.
+    /// A new format does not have to inherit that trap, so only nulls are omitted here. It costs a few bytes
+    /// per turn and removes a whole class of "it reverted on reload".</para>
+    ///
+    /// <para>The enum converter is load-bearing rather than tidy: <c>AiTask</c> and
+    /// <c>PageEdition</c> (inside <c>CitationRef.Pages</c>) are positional, and <b>[fsnow]</b>'s <i>"Forever,
+    /// no cap"</i> means files written today will be read by builds that may have inserted a preset or an
+    /// edition. Numbers would silently re-point; names cannot.</para>
+    ///
+    /// <para><b>Pāli is written as Pāli.</b> The default encoder escapes every non-ASCII character, which
+    /// turns a stored passage into pages of <c>ā</c> — these files are read by hand when something is
+    /// wrong with an answer, and that is the moment the text needs to be legible. <c>UnicodeRanges.All</c>
+    /// relaxes only that: <c>JavaScriptEncoder</c> still escapes the HTML-sensitive characters whatever range
+    /// it is given, so nothing here becomes safe to paste into a page that it was not before.</para>
+    /// </summary>
+    internal static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() },
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(
+            System.Text.Unicode.UnicodeRanges.All),
+    };
+
+    private readonly string _directory;
+    private readonly ILogger<AiSessionStore>? _logger;
+
+    // One write at a time. The temp file is per-session so two sessions could not collide anyway, but the
+    // same session being saved twice at once could — and that is the shape of the bug STATE-2 fixed in
+    // ApplicationStateService, where a shared .tmp let a half-written file be promoted over good data.
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+
+    public AiSessionStore(ILogger<AiSessionStore>? logger = null)
+        : this(Path.Combine(AppConstants.DataDirectory, DirectoryName), logger)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: point the store at a temp directory instead of the real one — the seam
+    /// <c>SettingsService</c> has had since #785 and <c>ApplicationStateService</c> gained in #877. Its absence
+    /// there is why the load and recovery paths had no coverage at all, so this one starts with it.
+    /// </summary>
+    internal AiSessionStore(string directory, ILogger<AiSessionStore>? logger = null)
+    {
+        _directory = directory;
+        _logger = logger;
+    }
+
+    public event Action<AiSessionUnreadable>? Unreadable;
+
+    // ---- reading ------------------------------------------------------------------------------------
+
+    public async Task<AiSession?> LoadAsync(string id, CancellationToken cancellationToken = default)
+    {
+        if (!IsWellFormedId(id))
+        {
+            _logger?.LogWarning("Refusing to read a session under a malformed id (#849)");
+            return null;
+        }
+
+        var path = PathFor(id);
+        if (!File.Exists(path)) return null;
+
+        return await ReadAsync(id, path, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<AiSessionSummary>> ListAsync(CancellationToken cancellationToken = default)
+    {
+        if (!Directory.Exists(_directory)) return Array.Empty<AiSessionSummary>();
+
+        string[] files;
+        try
+        {
+            files = Directory.GetFiles(_directory, "*.json");
+        }
+        catch (Exception ex)
+        {
+            // A directory that cannot be listed is an empty list, not an exception on the way to the panel.
+            _logger?.LogWarning(ex, "Could not list the assistant-sessions directory (#849)");
+            return Array.Empty<AiSessionSummary>();
+        }
+
+        var summaries = new List<AiSessionSummary>();
+
+        foreach (var file in files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var name = Path.GetFileNameWithoutExtension(file);
+
+            // Skip our own leavings rather than trying to read them: an `.unreadable-<stamp>.json` file is
+            // kept deliberately and is by definition not loadable, and a `.tmp` is not a session yet. Listing
+            // them would report the same broken transcript once per launch, forever.
+            if (!IsWellFormedId(name)) continue;
+
+            var session = await ReadAsync(name, file, cancellationToken).ConfigureAwait(false);
+            if (session is null) continue;
+
+            summaries.Add(new AiSessionSummary(
+                // The FILE's identity wins over the field's. They agree in every file this build writes; where
+                // they disagree the file name is what Load and Delete address, so a summary carrying the other
+                // one would produce a row that cannot be opened.
+                name,
+                session.Name,
+                session.Created,
+                session.LastActive,
+                session.Turns.Count,
+                DistinctBookIds(session)));
+        }
+
+        // Newest-active first (§3.3). Id breaks ties so the order is total rather than merely mostly-sorted:
+        // several sessions can share a timestamp after a restore, and a list that reshuffles between launches
+        // is a list the reader cannot learn.
+        return summaries
+            .OrderByDescending(s => s.LastActive)
+            .ThenBy(s => s.Id, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// The books this conversation's citations name, de-duplicated, in first-appearance order.
+    ///
+    /// <para>First-appearance rather than alphabetical: the row is read as "what this conversation was about",
+    /// and the book it started with is the one that says that. Turns with no citation contribute nothing — a
+    /// failed turn often has none.</para>
+    /// </summary>
+    private static IReadOnlyList<string> DistinctBookIds(AiSession session)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var ordered = new List<string>();
+
+        foreach (var turn in session.Turns)
+        {
+            var bookId = turn.Citation?.BookId;
+            if (string.IsNullOrWhiteSpace(bookId)) continue;
+            if (seen.Add(bookId!)) ordered.Add(bookId!);
+        }
+
+        return ordered;
+    }
+
+    /// <summary>
+    /// Read one file, or keep it aside and report it. Never throws for the file's own sake — only cancellation
+    /// propagates.
+    /// </summary>
+    private async Task<AiSession?> ReadAsync(string id, string path, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var json = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+            var session = JsonSerializer.Deserialize<AiSession>(json, JsonOptions);
+
+            // A file holding the literal token `null` deserializes to null without throwing; an empty file
+            // throws. Both are "this is not a session", and both must take the preserve path — the shape of
+            // the failure is not the reader's problem.
+            if (session is null)
+            {
+                PreserveUnreadable(id, path, "the file did not contain a session");
+                return null;
+            }
+
+            // Trust the file name over the field, for the reason given in ListAsync: it is what Load, Save and
+            // Delete address. A mismatch means someone renamed a file by hand, and honouring it is the
+            // behaviour that makes that work rather than producing a session that saves itself elsewhere.
+            session.Id = id;
+
+            // A property initializer does NOT survive an explicit null in the file: `"turns": null` sets the
+            // member to null, initializer and all. Everything downstream — this store's own summary, and the
+            // panel rebuilding the transcript — then meets a null collection where the type promises one, and
+            // a NullReferenceException out of a listing is precisely the "cannot open the panel" failure the
+            // rest of this class goes to lengths to avoid. Nothing this build writes produces such a file; a
+            // hand-edit or a truncating tool does.
+            session.Name ??= string.Empty;
+            session.Turns ??= new List<AiTurnRecord>();
+            session.Turns.RemoveAll(t => t is null);
+            foreach (var turn in session.Turns)
+                turn.Notices ??= new List<string>();
+
+            return session;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            PreserveUnreadable(id, path, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Move an unreadable session aside under a timestamped name, then report it.
+    ///
+    /// <para>Nothing else would keep it: the next turn in that conversation rewrites the file, and the
+    /// reader's transcript is gone with no way back even by hand. Milliseconds in the name, like the app-state
+    /// backups, so two failed reads in one second cannot collide. (#877's pattern.)</para>
+    /// </summary>
+    private void PreserveUnreadable(string id, string path, string error)
+    {
+        var kept = path;
+
+        try
+        {
+            kept = Path.Combine(
+                _directory,
+                $"{id}.unreadable-{DateTime.Now:yyyyMMdd-HHmmss-fff}.json");
+
+            File.Move(path, kept, overwrite: false);
+
+            _logger?.LogError(
+                "The assistant session {Id} could not be read ({Error}) and has been kept at {Path}. "
+                + "Nothing in it was deleted.", id, error, kept);
+        }
+        catch (Exception ex)
+        {
+            // Reporting still happens. A file we could not move is still a file we could not read, and the
+            // panel's notice is the reader's only sign of either.
+            kept = path;
+            _logger?.LogWarning(ex, "Could not preserve the unreadable assistant session {Id}", id);
+        }
+
+        Unreadable?.Invoke(new AiSessionUnreadable(id, kept, error));
+    }
+
+    // ---- writing ------------------------------------------------------------------------------------
+
+    public async Task<bool> SaveAsync(AiSession session, CancellationToken cancellationToken = default)
+    {
+        if (session is null) return false;
+
+        if (!IsWellFormedId(session.Id))
+        {
+            _logger?.LogWarning("Refusing to write a session under a malformed id (#849)");
+            return false;
+        }
+
+        string json;
+        try
+        {
+            json = JsonSerializer.Serialize(session, JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            // Serialize BEFORE touching the file. A type that cannot be written must not be able to take the
+            // previous good transcript with it, which is what a stream-straight-to-the-file version would do.
+            _logger?.LogError(ex, "Could not serialize assistant session {Id}", session.Id);
+            return false;
+        }
+
+        var path = PathFor(session.Id);
+        var temp = path + ".tmp";
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(_directory);
+
+            await File.WriteAllTextAsync(temp, json, cancellationToken).ConfigureAwait(false);
+
+            // Temp then replace. The window in which a session file is half-written is the window in which a
+            // crash costs the reader the whole conversation rather than the turn in flight, and it closes for
+            // free.
+            if (File.Exists(path)) File.Replace(temp, path, null);
+            else File.Move(temp, path);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Cancellation is caught here too, unlike on the read side where it propagates. The asymmetry is
+            // deliberate: a cancelled save has written nothing the caller can use, and "false, and the temp
+            // file is gone" is the whole of what it needs to know — while a cancelled READ must not be
+            // mistaken for a session that could not be read, which would move a perfectly good file aside.
+            _logger?.LogError(ex, "Could not write assistant session {Id} to {Path}", session.Id, path);
+
+            try
+            {
+                if (File.Exists(temp)) File.Delete(temp);
+            }
+            catch (Exception cleanupEx)
+            {
+                _logger?.LogWarning(cleanupEx, "Could not clean up {Path}", temp);
+            }
+
+            return false;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default)
+    {
+        if (!IsWellFormedId(id))
+        {
+            _logger?.LogWarning("Refusing to delete under a malformed id (#849)");
+            return Task.FromResult(false);
+        }
+
+        var path = PathFor(id);
+
+        try
+        {
+            if (!File.Exists(path)) return Task.FromResult(false);
+
+            File.Delete(path);
+            _logger?.LogInformation("Deleted assistant session {Id}", id);
+            return Task.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Could not delete assistant session {Id}", id);
+            return Task.FromResult(false);
+        }
+    }
+
+    // ---- paths --------------------------------------------------------------------------------------
+
+    private string PathFor(string id) => Path.Combine(_directory, id + ".json");
+
+    /// <summary>
+    /// Whether an id may be turned into a file name: letters, digits, <c>-</c> and <c>_</c>, at most 64 of
+    /// them.
+    ///
+    /// <para><b>Why a store validates its own keys.</b> Every id reaching it comes from outside — a directory
+    /// listing, <c>ActiveAssistantSessionId</c> in a JSON file a reader can edit, and later whatever the
+    /// surface-C API hands in. <c>Path.Combine</c> with <c>"../../settings"</c> is a path outside the data
+    /// directory, and the operations here are read, overwrite and delete. The check also keeps the store's own
+    /// leavings out of the listing for free: <c>&lt;id&gt;.unreadable-&lt;stamp&gt;</c> contains a <c>.</c> and
+    /// is rejected by the same rule.</para>
+    /// </summary>
+    internal static bool IsWellFormedId(string? id)
+    {
+        if (string.IsNullOrEmpty(id) || id.Length > 64) return false;
+
+        foreach (var c in id)
+        {
+            var ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+                     || c == '-' || c == '_';
+            if (!ok) return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Part of #849 — P2's storage layer from [ASSISTANT_SESSIONS.md](docs/features/planned/ASSISTANT_SESSIONS.md) §3.2. Store and models only; the panel wiring (capture at `StartTurn`, save at `EndTurn`, restore at launch) is the next PR. Does not close #849.

**What it adds.** `IAiSessionStore` + `AiSessionStore` — one JSON file per session under `<DataDirectory>/assistant-sessions/`, atomic write (temp + `File.Replace`), an unreadable file moved aside as `<id>.unreadable-<stamp>.json` and reported through an event rather than thrown, `ListAsync` summaries newest-active first with the distinct book ids from the citations. `AiSession` / `AiTurnRecord` and the stored shapes they hold (`AiSentRecord`, `AiCitationRecord`, `AiPageRecord`, `AiCompactionRecord`), every level with `[JsonExtensionData]` so an older build rewriting a newer file drops nothing. One field on `ApplicationState`: `ActiveAssistantSessionId`. One DI line.

**Decisions honoured** (**[fsnow]**, plan §6): the sent prompt stored in full (system prompt + user content); one global list; no retention; the structured `CitationRef` and the #434 `ReadingPositionToken` carried per turn for "take me back".

**Two shape decisions made in review, by the parent session, inside those decisions:**
- **The file never serializes a live UI type.** Fable's probe showed that storing `SentContext` whole would freeze #991's computed `HasHistory` into every file and that the positional records inside have no unknown-field protection, so a newer build's nested field would be silently dropped on rewrite. Stored types are the store's own.
- **Replayed history is stored by reference** (`ReplayedTurnIds` + the rendered `AskedLine` per turn), not by value: by value embeds every earlier answer in every later turn — measured **966 KB vs 251 KB (3.85×)** for a 30-turn session — and all of it is reconstructible from the earlier records, which never change. A session-level `Compactions` slot holds the one non-reconstructible piece (P4's summaries), empty for now.

Also, following #995's marker decision (**[fsnow]**: *"I want to fix this before we merge"*): the record stores both `Answer` (stripped, to render) and `MarkedAnswer` (as the model wrote it, to replay), so a session restored from disk cannot feed the model marker-free transcripts through the restore path (`b75521e`). Also from review: usage stored as two ints and elapsed as milliseconds rather than display strings; `SaveAsync` no longer throws on a cancelled token; `Pages` null-hardened; a fault-injection test proves the previous file is byte-identical when a write fails mid-way.

**Where the plan was wrong, found here:** plan §1's "a turn already carries everything a stored record needs" is false for the citation (the view model keeps only display strings; `Handle` drops the `CitationRef`), for provider/model ids (nowhere), and for structured usage (dropped after formatting). The record doc names what the wiring PR must capture.

**Review.** Fable adversarial review: mergeable with named fixes — all applied in `cb67826`. Merges cleanly with `main` and with #995. Left as noted, not fixed: `IsWellFormedId` accepts Windows device names (`CON`, `NUL`); reachable only by hand-editing `application-state.json`, and the outcome is a logged `false`, not data loss.

**Tests.** 2857 → 2888 passed, 0 failed, 18 skipped; 31 in the store's suite plus a checked-in golden session file so any format change is a visible diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

