### PR TITLE
Keep the Assistant conversation across launches (#849 P2 — wiring)

### DIFF
--- a/docs/features/planned/ASSISTANT_SESSIONS.md
+++ b/docs/features/planned/ASSISTANT_SESSIONS.md
@@ -43,14 +43,21 @@ Two things make the rest cheaper than it looks:
   `User` and `Assistant`, and both adapters iterate the list (`OpenAiCompatibleProvider.cs:237`,
   `AnthropicMessagesProvider.cs:251`). Only the orchestrator's single-message construction stands between the
   app and a conversation.
-- **[observed] A turn already carries everything a stored record needs.** `AiTurnViewModel` holds the task,
-  question, raw answer, reasoning, citation, notices, partial-passage flag, usage, elapsed, and the
-  `SentContext` (#665) with both prompt halves. `CitationRef` carries `BookId` + `NormalizedReference`;
-  `ReadingPositionToken` (#434) is the persisted position format. Nothing new has to be *computed* for
-  persistence — only written down.
+- **[observed] A turn holds the display strings but not the facts they were made from.** `AiTurnViewModel` has
+  the task, question, raw answer, marked answer, reasoning, notices, partial-passage flag and the `SentContext`
+  (#665) — and, for the rest, only what is on screen. Four things a record needs were **not reachable from a
+  turn** at the end of it:
+  - the structured `CitationRef` — it arrived once on the `Started` event and `Handle` replaced it with two
+    rendered lines, so nothing left named a file to reopen;
+  - the `AiUsageReport` — formatted by `FormatUsage` and dropped, leaving a `:N0`-grouped string;
+  - the elapsed duration — only `FormatElapsed`'s `"4.2s"`, and the panel's one stopwatch is restarted by the
+    next turn;
+  - the provider and model ids — on neither `AiTurnContext` nor the view model, so carrying them needed a
+    contract change rather than a read from the panel.
 
-**[observed] `ClearCommand` is bound to nothing** (#850). `AiAssistantPanel.axaml` never references it; the
-command exists, is guarded against `IsBusy`, and is unreachable.
+  So the wiring is not "only written down": the turn had to start keeping the originals beside the strings
+  derived from them. Nothing bound in the panel changed. (Corrected 2026-09-12, after building it — the
+  original claim here was wrong, and the store's record docs were written against the corrected list.)
 
 ## 2. Claude Code parity map
 
@@ -138,20 +145,30 @@ the Claude Code guarantee. Atomic write (temp + `File.Replace`), the pattern `Ap
 
 | field | source | note |
 |---|---|---|
-| task, question | `AiTurnViewModel` | |
-| citation (`CitationRef`) | `AiTurnContext.Citation` | **required** — #849 comment 2: this is what makes "take me back" possible |
+| id, task, question, when | `AiTurnViewModel` | the id is minted at construction, so a later turn can point at this one while it is still on screen |
+| citation (`CitationRef`) | `AiTurnContext.Citation`, kept on the turn as `StructuredCitation` | **required** — #849 comment 2: this is what makes "take me back" possible |
 | subject (selection summary) | `Subject` | display text only; the full selection is in the sent prompt |
-| answer (raw), reasoning | builders | reasoning is shown collapsed today; storing it keeps the turn faithful |
+| answer (raw), marked answer, reasoning | builders | both answer halves: the stripped one renders, the marked one replays (#991) |
 | notices, partial-passage flag | `Notices`, `IsPartialPassage` | |
-| usage, elapsed, status, failed | | |
-| sent context (`SentContext`) | #665 | see the decision in §6 — [suggestion] store it |
-| reading position (`ReadingPositionToken`) | captured from the active book at `StartTurn` | #849 comment 3; **new capture**, the only new data |
-| provider id, model id, when | | the model that answered is part of the record |
+| usage (two ints), elapsed (ms), status, failed | `UsageReport` and `ElapsedTime` on the turn | numbers, not the `:N0`/`"4.2s"` strings printed from them |
+| asked line | `DescribeAsked(turn)` | derivable from *today's* wording, so stored: a record of what a model saw must not re-render itself |
+| sent context (`SentContext`) | #665, mapped to `AiSentRecord` | prompt halves and fields by value; the replayed conversation by **id** — a 30-turn file would otherwise hold 435 copies of its own answers |
+| reading position (`ReadingPositionToken`) | `ReaderState.ReadingPosition`, captured at `StartTurn` | #849 comment 3; **new capture** — read from `BookDisplayViewModel.LastPositionToken`, the rolling ~200 ms token the dock factory already persists, rather than by a fresh WebView round trip |
+| provider id, model id | `AiTurnContext.ProviderId`/`ModelId` (**new** on that contract) | the model that answered is part of the record |
 
-**Restore:** at launch the panel reads the active session and rebuilds `Turns` from records — a
-constructor `AiTurnViewModel(AiTurnRecord)` alongside the live one, with `IsRunning = false`. No model call.
-A session file that fails to parse is moved aside with a timestamp (the `application-state.unreadable-*`
-pattern) and the panel starts empty with a notice, never a crash.
+**Restore:** at launch the panel reads the active session and rebuilds `Turns` from records —
+`AiTurnViewModel.FromRecord(record, byId)` alongside the live constructor, with `IsRunning = false` and the
+answer published (`Blocks` exist only after `PublishAnswer`). No model call. A session file that fails to parse
+is moved aside with a timestamp (the `application-state.unreadable-*` pattern) and the panel starts empty with a
+notice, never a crash.
+
+**[observed] Launch sequencing.** The panel's view model is built during `CstDockFactory.CreateLayout`, which
+runs *before* `LoadStateAsync` completes — so a constructor reading `ActiveAssistantSessionId` would read the
+default empty state every launch. The restore is therefore pushed in by `App.InitializeFromLoadedState`, as
+`AiAssistantViewModel.RestoreAsync()`, next to `SearchViewModel.ApplyState` (#87) and
+`DictionaryViewModel.ApplyState` (#479), which exist for exactly this. It is gated on
+`CstDockFactory.AssistantEnabled()`, because resolving the singleton would otherwise *create* a panel for a
+reader who has the feature switched off.
 
 ### 3.3 Sessions (P0, P3)
 
@@ -161,9 +178,10 @@ current one."* So the control is **+** — new conversation: the current session
 every `EndTurn`), and the panel starts an empty one. Nothing is destroyed, so it needs no confirmation.
 `ClearCommand` and `Clear()` are removed, not rebound; #850 is rewritten to describe the + control.
 
-For P0, before the session store exists, + does what `Clear()` did — empties the transcript — because there
-is nothing to save yet. The control and its meaning survive P2/P3 unchanged; only what happens underneath
-grows.
+**[observed] The command exists as of the P2 wiring: `NewConversationCommand`** — `IsBusy`-guarded like every
+other, it clears `Turns`, drops the session, and clears `ActiveAssistantSessionId`. It saves nothing, because
+every turn was already written when it ended. `ClearCommand`/`Clear()` are gone. What is left for #850 is the
+button.
 
 **Deletion** is a separate action on a row in the session list, and it confirms — the one irreversible thing
 here. **[fsnow]** chose *"Yes, with confirmation"*.

--- a/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
+++ b/src/CST.Avalonia.Tests/Services/Ai/AiChatOrchestratorTests.cs
@@ -208,6 +208,29 @@ public class AiChatOrchestratorTests
         Assert.Equal("Dhammapadapāḷi", started.Book.Name);
     }
 
+    /// <summary>
+    /// The context names the connection and model that answered — structured, not only printed in the Sent
+    /// block. (#849)
+    ///
+    /// <para>A stored turn has to be attributable, and a conversation spanning a model change is the ordinary
+    /// case rather than a corner of it. These ids were on neither this contract nor the panel before, so the
+    /// alternative was for the panel to match a <c>SentField</c> by its English label — the same mistake as
+    /// deriving the partial-passage flag from the wording of a notice.</para>
+    /// </summary>
+    [Fact]
+    public async Task The_context_says_which_connection_and_model_answered()
+    {
+        var events = await CollectAsync(Orchestrator(new FakeProvider()));
+
+        var started = Assert.IsType<AiTurnContext>(events[0].Context);
+        Assert.Equal("fake", started.ProviderId);
+        Assert.Equal("test-model", started.ModelId);
+
+        // The same two values the reader can already read in the Sent block, which is the point: one source.
+        Assert.Equal("fake", started.Sent!.Fields.Single(f => f.Name == "Provider").Value);
+        Assert.Equal("test-model", started.Sent.Fields.Single(f => f.Name == "Model").Value);
+    }
+
     [Fact]
     public async Task The_configured_answer_language_reaches_the_bundle()
     {

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantSessionWiringTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantSessionWiringTests.cs
@@ -1,0 +1,775 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using CST.Avalonia.Models;
+using CST.Avalonia.Services;
+using CST.Avalonia.Services.Ai;
+using CST.Avalonia.ViewModels;
+using Moq;
+using Xunit;
+
+// The stubs and context helpers the live-turn suite next door already owns. Shared rather than copied: a
+// second StubOrchestrator would drift from the first, and most of what is asserted here is that a restored turn
+// equals a live one — which is only worth asserting if both were built the same way.
+using static CST.Avalonia.Tests.ViewModels.AiAssistantViewModelTests;
+
+namespace CST.Avalonia.Tests.ViewModels;
+
+/// <summary>
+/// The Assistant panel's conversation, written down and read back. (#849 P2 wiring)
+///
+/// <para><b>[fsnow]</b>: <i>"Restore the last session silently"</i> — so the behaviour under test is a panel
+/// that reopens where it was left, with no model call and nothing asked of the reader. Two properties carry
+/// most of the weight: <b>what a record holds</b> (everything the panel shows, plus the structured originals
+/// the display strings were made from), and <b>that a restored turn is indistinguishable from a live one</b> —
+/// including to <c>HistoryFor</c>, because a follow-up after a restart has to continue the conversation rather
+/// than start one.</para>
+///
+/// <para>The store is faked rather than pointed at a temp directory: <c>AiSessionStoreTests</c> already covers
+/// the file layer against a real one, and what is left to pin here is the panel's side of the contract — when
+/// it saves, what it puts in the record, and what it does when a save fails.</para>
+/// </summary>
+public class AiAssistantSessionWiringTests
+{
+    /// <summary>
+    /// A store that records rather than writes. <b>Answers, never throws</b> — the same contract the real one
+    /// keeps, which is what makes "a failed save is a sentence" testable at all.
+    /// </summary>
+    private sealed class FakeStore : IAiSessionStore
+    {
+        internal AiSession? ToLoad { get; set; }
+
+        /// <summary>Fired from <see cref="LoadAsync"/> when set, where the real store fires it.</summary>
+        internal AiSessionUnreadable? ReportOnLoad { get; set; }
+
+        internal string? AskedFor { get; private set; }
+        internal bool SaveSucceeds { get; set; } = true;
+
+        /// <summary>Every session handed to <see cref="SaveAsync"/>, by reference — the panel mutates one
+        /// object, so how many turns it held AT each save is recorded separately.</summary>
+        internal List<AiSession> Saves { get; } = new();
+
+        internal List<int> TurnCountAtSave { get; } = new();
+
+        internal AiSession? LastSaved => Saves.Count == 0 ? null : Saves[^1];
+
+        public Task<AiSession?> LoadAsync(string id, CancellationToken cancellationToken = default)
+        {
+            AskedFor = id;
+            if (ReportOnLoad is { } report) Unreadable?.Invoke(report);
+            return Task.FromResult(ToLoad);
+        }
+
+        public Task<bool> SaveAsync(AiSession session, CancellationToken cancellationToken = default)
+        {
+            Saves.Add(session);
+            TurnCountAtSave.Add(session.Turns.Count);
+            return Task.FromResult(SaveSucceeds);
+        }
+
+        public Task<IReadOnlyList<AiSessionSummary>> ListAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<AiSessionSummary>>(Array.Empty<AiSessionSummary>());
+
+        public Task<bool> DeleteAsync(string id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+
+        public event Action<AiSessionUnreadable>? Unreadable;
+    }
+
+    /// <summary>Streams a little and is then cancelled — the reader's own Stop, which the stub next door cannot
+    /// express because it ends by running out of events rather than by being cancelled.</summary>
+    private sealed class StoppedOrchestrator : IAiChatOrchestrator
+    {
+        public async IAsyncEnumerable<AiTurnEvent> RunAsync(
+            AiTurnRequest request, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return AiTurnEvent.ForStarted(Context());
+            yield return AiTurnEvent.ForText("Half an answer", "Half an answer");
+            await Task.Yield();
+            throw new OperationCanceledException();
+        }
+
+        public void Stop()
+        {
+        }
+    }
+
+    /// <summary>Holds a turn open at a known point, so "while a turn is running" is a state a test can be in
+    /// rather than a race it has to win.</summary>
+    private sealed class BlockingOrchestrator : IAiChatOrchestrator
+    {
+        internal TaskCompletionSource Gate { get; } = new();
+
+        public async IAsyncEnumerable<AiTurnEvent> RunAsync(
+            AiTurnRequest request, [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return AiTurnEvent.ForStarted(Context());
+            await Gate.Task;
+            yield return AiTurnEvent.ForCompleted(new PaliMarkerReport(0, 0));
+        }
+
+        public void Stop()
+        {
+        }
+    }
+
+    private static (AiAssistantViewModel Vm, FakeStore Store, ApplicationState State,
+        Mock<IApplicationStateService> StateService) Panel(
+            IAiChatOrchestrator orchestrator, StubReaderState? reader = null, FakeStore? store = null,
+            ApplicationState? state = null)
+    {
+        store ??= new FakeStore();
+        state ??= new ApplicationState();
+
+        var stateService = new Mock<IApplicationStateService>();
+        stateService.SetupGet(x => x.Current).Returns(state);
+
+        var vm = new AiAssistantViewModel(
+            orchestrator, reader ?? new StubReaderState(), null, null, null, null, store, stateService.Object);
+
+        return (vm, store, state, stateService);
+    }
+
+    /// <summary>What #665 records about a request. Non-null here because the replayed-turn ids live inside it —
+    /// a turn that sent nothing has nothing to say about what it replayed either.</summary>
+    private static SentContext Sent() =>
+        new(new[] { new SentField("Provider", "openrouter"), new SentField("Model", "some/model") },
+            "The system prompt.", "The user message.");
+
+    /// <summary>A context that also names the connection that answered — what #849 added to
+    /// <c>AiTurnContext</c> so a stored answer is attributable.</summary>
+    private static AiTurnContext ContextFrom(string providerId = "openrouter", string modelId = "some/model") =>
+        new(AiTask.Explain, "English", Citation(),
+            new BookContext("s0101m.mul.xml", "book", CST.Pitaka.Sutta, CST.CommentaryLevel.Mula),
+            Array.Empty<string>(), false, Sent(), providerId, modelId);
+
+    private static StubOrchestrator AnsweringFrom(AiTurnContext context, params AiTurnEvent[] middle)
+    {
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(context));
+        orchestrator.Events.AddRange(middle);
+        orchestrator.Events.Add(AiTurnEvent.ForCompleted(new PaliMarkerReport(0, 0)));
+        return orchestrator;
+    }
+
+    // ---- Saving ----------------------------------------------------------------------------------
+
+    /// <summary>
+    /// The first turn to END creates the conversation, names it from itself, and tells application state which
+    /// file to reopen. <b>[fsnow]</b> chose <i>"Auto from the first turn, renamable"</i>.
+    /// </summary>
+    [Fact]
+    public async Task The_first_turn_creates_a_named_session_and_records_which_one_is_active()
+    {
+        var (vm, store, state, stateService) = Panel(Answering(Said("Heedfulness is the path.")));
+
+        await vm.AskAsync(AiTask.Explain);
+
+        var saved = Assert.IsType<AiSession>(store.LastSaved);
+
+        // Named from the turn: the preset that was pressed and the passage it was about. Not by a model —
+        // nothing about a name costs a call.
+        Assert.Equal(
+            $"Explain · {AiAssistantViewModel.Describe(Citation())}",
+            saved.Name);
+        Assert.Single(saved.Turns);
+        Assert.NotEqual(default, saved.Created);
+
+        // One string in application state, so the next launch knows which transcript to read.
+        Assert.Equal(saved.Id, state.ActiveAssistantSessionId);
+        stateService.Verify(x => x.MarkDirty(), Times.AtLeastOnce);
+    }
+
+    /// <summary>
+    /// A typed question names its own conversation. The preset label and the citation would be identical on
+    /// every question asked about one passage, and the words are what the reader recognises in a list.
+    /// </summary>
+    [Fact]
+    public async Task A_question_names_its_conversation_by_its_own_first_words()
+    {
+        var (vm, store, _, _) = Panel(Answering(Said("It means vigilance.")));
+
+        vm.Question = new string('a', 40) + " " + new string('b', 40);
+        await vm.AskAsync(AiTask.Ask);
+
+        var name = store.LastSaved!.Name;
+
+        // 60 characters and an ellipsis, cut at the end rather than elided in the middle: a name is read from
+        // its start, and a list of names sharing a prefix is what the reader is scanning.
+        Assert.StartsWith(new string('a', 40), name);
+        Assert.EndsWith("…", name);
+        Assert.Equal(61, name.Length);
+    }
+
+    /// <summary>
+    /// Every turn rewrites the WHOLE session, which is why a crash costs the turn in flight and nothing else.
+    /// </summary>
+    [Fact]
+    public async Task Each_turn_that_ends_rewrites_the_whole_conversation()
+    {
+        var (vm, store, _, _) = Panel(Answering(Said("An answer.")));
+
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+        await vm.AskAsync(AiTask.Grammar);
+
+        Assert.Equal(new[] { 1, 2, 3 }, store.TurnCountAtSave);
+
+        // One conversation, added to — not three files.
+        Assert.Single(store.Saves.Select(s => s.Id).Distinct());
+        Assert.Equal(3, store.LastSaved!.Turns.Count);
+    }
+
+    /// <summary>
+    /// A stopped turn is stored with whatever had arrived. It is on screen and the reader is reading it, so it
+    /// belongs in the record — and the reader's own cancellation must not be what breaks the save that keeps it.
+    /// </summary>
+    [Fact]
+    public async Task A_stopped_turn_is_saved_with_the_text_that_had_arrived()
+    {
+        var (vm, store, _, _) = Panel(new StoppedOrchestrator());
+
+        await vm.AskAsync(AiTask.Explain);
+
+        var record = Assert.Single(store.LastSaved!.Turns);
+        Assert.Equal("Half an answer", record.Answer);
+        Assert.Equal("Half an answer", record.MarkedAnswer);
+        Assert.Equal("Stopped.", record.Status);
+        Assert.False(record.Failed);
+    }
+
+    /// <summary>A failed turn is stored too, marked as one — a transcript that dropped its failures would reopen
+    /// claiming a conversation went better than it did.</summary>
+    [Fact]
+    public async Task A_failed_turn_is_saved_and_marked_failed()
+    {
+        var orchestrator = new StubOrchestrator();
+        orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));
+        orchestrator.Events.Add(Said("Part of an answer"));
+        orchestrator.Events.Add(AiTurnEvent.ForError(new AiError(AiErrorKind.Network, "The connection dropped.")));
+        var (vm, store, _, _) = Panel(orchestrator);
+
+        await vm.AskAsync(AiTask.Explain);
+
+        var record = Assert.Single(store.LastSaved!.Turns);
+        Assert.Equal("Part of an answer", record.Answer);
+        Assert.True(record.Failed);
+        Assert.Equal("The connection dropped.", record.Status);
+    }
+
+    /// <summary>
+    /// The record carries what the view model only DISPLAYED — the structured citation, the connection that
+    /// answered, the token counts as numbers, the duration as a duration, and both halves of the answer.
+    ///
+    /// <para>Every one of these was dropped before the wiring: the citation arrived once on <c>Started</c> and
+    /// was replaced by two rendered lines, the usage report was formatted and discarded, elapsed existed only
+    /// as <c>"4.2s"</c>, and the provider and model ids were on nothing at all.</para>
+    /// </summary>
+    [Fact]
+    public async Task The_record_carries_the_structured_facts_the_panel_only_rendered()
+    {
+        var orchestrator = AnsweringFrom(
+            ContextFrom(),
+            AiTurnEvent.ForText("The term appamada matters.", "The term [[appamada]] matters."),
+            AiTurnEvent.ForReasoning("Thinking about the compound."),
+            AiTurnEvent.ForUsage(new AiUsageReport(1024, 256)));
+        var (vm, store, _, _) = Panel(orchestrator);
+
+        await vm.AskAsync(AiTask.Explain);
+
+        var record = Assert.Single(store.LastSaved!.Turns);
+
+        // The citation as data, not as the line drawn from it: this is what a later "take me back" (P5) opens.
+        Assert.Equal("s0101m.mul.xml", record.Citation!.BookId);
+        Assert.Equal("para 12", record.Citation.NormalizedReference);
+
+        Assert.Equal("openrouter", record.ProviderId);
+        Assert.Equal("some/model", record.ModelId);
+
+        // Numbers, not the line printed from them: that line has been through :N0 and reads differently on a
+        // machine with different digit grouping, and nothing can be added up from it afterwards.
+        Assert.Equal(1024, record.InputTokens);
+        Assert.Equal(256, record.OutputTokens);
+
+        Assert.NotNull(record.ElapsedMs);
+        Assert.True(record.ElapsedMs >= 0);
+
+        // Both halves: the stripped form is what the panel renders, the marked form is what a later turn
+        // replays to the model. (#991)
+        Assert.Equal("The term appamada matters.", record.Answer);
+        Assert.Equal("The term [[appamada]] matters.", record.MarkedAnswer);
+        Assert.Equal("Thinking about the compound.", record.Reasoning);
+
+        // The question side as the model was shown it, stored rather than left to be re-rendered later.
+        Assert.Equal(AiAssistantViewModel.DescribeAsked(vm.LastTurn!), record.AskedLine);
+
+        // And what was sent, in full — [fsnow]: "Yes, in full".
+        Assert.Equal("The system prompt.", record.Sent!.SystemPrompt);
+        Assert.Equal("The user message.", record.Sent.UserContent);
+        Assert.Equal(2, record.Sent.Fields.Count);
+
+        Assert.NotEqual(default, record.When);
+    }
+
+    /// <summary>
+    /// The reading position is taken at turn START. <b>[fsnow]</b>: <i>"The Assistant's memory should carry the
+    /// same scroll context saved elsewhere: two anchors and a fraction between them."</i>
+    ///
+    /// <para>At the start and not the end, because by the time an answer arrives the reader may have scrolled
+    /// on — and the position a stored turn asks to be taken back to is the one it was asked from.</para>
+    /// </summary>
+    [Fact]
+    public async Task The_reading_position_at_turn_start_is_stored_with_the_turn()
+    {
+        var reader = new StubReaderState
+        {
+            Result = ReaderStateResult.Ok(new ReaderState(
+                "s0101m.mul.xml", 12, null,
+                ReadingPosition: new ReadingPositionToken
+                {
+                    Above = "para12", Below = "para13", Fraction = 0.25,
+                })),
+        };
+        var (vm, store, _, _) = Panel(Answering(Said("An answer.")), reader);
+
+        await vm.AskAsync(AiTask.Explain);
+
+        var position = Assert.IsType<ReadingPositionToken>(store.LastSaved!.Turns[0].ReadingPosition);
+        Assert.Equal("para12", position.Above);
+        Assert.Equal("para13", position.Below);
+        Assert.Equal(0.25, position.Fraction);
+    }
+
+    /// <summary>A turn asked before the anchor cache had built keeps everything else. A reading position is
+    /// worth having and no turn is worth refusing for the want of one.</summary>
+    [Fact]
+    public async Task A_turn_with_no_reading_position_is_still_stored()
+    {
+        var (vm, store, _, _) = Panel(Answering(Said("An answer.")));
+
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.Null(store.LastSaved!.Turns[0].ReadingPosition);
+        Assert.Equal("An answer.", store.LastSaved.Turns[0].Answer);
+    }
+
+    /// <summary>
+    /// The record names the turns that were ACTUALLY replayed, by id — not by copying their answers into it, and
+    /// not by recomputing later which turns would be replayed now.
+    /// </summary>
+    [Fact]
+    public async Task The_record_names_the_turns_that_were_replayed_ahead_of_it()
+    {
+        var orchestrator = AnsweringFrom(ContextFrom(), Said("An answer."));
+        var (vm, store, _, _) = Panel(orchestrator);
+
+        await vm.AskAsync(AiTask.Explain);
+        await vm.AskAsync(AiTask.Translate);
+        await vm.AskAsync(AiTask.Grammar);
+
+        var turns = store.LastSaved!.Turns;
+
+        // A first turn replays nothing.
+        Assert.Empty(turns[0].Sent!.ReplayedTurnIds);
+
+        // Each later one names its predecessors, in the order they were sent...
+        Assert.Equal(new[] { turns[0].Id }, turns[1].Sent!.ReplayedTurnIds);
+        Assert.Equal(new[] { turns[0].Id, turns[1].Id }, turns[2].Sent!.ReplayedTurnIds);
+
+        // ...which is exactly the history the orchestrator was handed, one exchange per named turn.
+        Assert.Equal(2, orchestrator.Requests[2].History!.Count);
+    }
+
+    /// <summary>
+    /// A save that fails says so in one sentence and breaks nothing. The answer is on screen; losing it to a
+    /// problem with a file would be the larger harm.
+    /// </summary>
+    [Fact]
+    public async Task A_failed_save_is_a_sentence_and_not_an_exception()
+    {
+        var store = new FakeStore { SaveSucceeds = false };
+        var (vm, _, _, _) = Panel(Answering(Said("An answer.")), store: store);
+
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.Contains("could not be saved", vm.Status);
+
+        // The turn itself is untouched — it ran, it answered, and it is not marked failed.
+        Assert.Equal("An answer.", vm.LastTurn!.Answer);
+        Assert.False(vm.LastTurn.Failed);
+        Assert.False(vm.IsBusy);
+    }
+
+    /// <summary>A panel with no store is a panel that forgets, not one that fails — which is the whole reason
+    /// both new dependencies are optional. (Every test in the suite next door constructs one.)</summary>
+    [Fact]
+    public async Task A_panel_with_no_store_still_runs_a_turn()
+    {
+        var vm = new AiAssistantViewModel(Answering(Said("An answer.")), new StubReaderState(), null, null);
+
+        await vm.AskAsync(AiTask.Explain);
+
+        Assert.Equal("An answer.", vm.LastTurn!.Answer);
+        Assert.Equal("", vm.Status);
+    }
+
+    // ---- Restoring -------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A restored turn renders as the live one that produced it. Compared field by field against a live turn
+    /// built from the same events, because "renders identically" is not a property any single assertion has.
+    /// </summary>
+    [Fact]
+    public async Task A_restored_turn_renders_as_the_live_one_that_produced_it()
+    {
+        var orchestrator = AnsweringFrom(
+            ContextFrom(),
+            AiTurnEvent.ForText("The term **appamada** matters.", "The term **[[appamada]]** matters."),
+            AiTurnEvent.ForReasoning("Thinking about the compound."),
+            AiTurnEvent.ForUsage(new AiUsageReport(1024, 256)));
+        var (vm, store, _, _) = Panel(orchestrator);
+
+        vm.Question = "what does the second word mean?";
+        await vm.AskAsync(AiTask.Ask);
+
+        var live = vm.LastTurn!;
+        var restored = AiTurnViewModel.FromRecord(store.LastSaved!.Turns[0]);
+
+        Assert.Equal(live.Task, restored.Task);
+        Assert.Equal(live.Question, restored.Question);
+        Assert.Equal(live.HasQuestion, restored.HasQuestion);
+        Assert.Equal(live.PresetLabel, restored.PresetLabel);
+        Assert.Equal(live.Answer, restored.Answer);
+        Assert.Equal(live.HasAnswer, restored.HasAnswer);
+        Assert.Equal(live.CopyText, restored.CopyText);
+        Assert.Equal(live.Reasoning, restored.Reasoning);
+        Assert.Equal(live.HasReasoning, restored.HasReasoning);
+        Assert.Equal(live.ReasoningHeader, restored.ReasoningHeader);
+        Assert.Equal(live.Citation, restored.Citation);
+        Assert.Equal(live.CitationDetail, restored.CitationDetail);
+        Assert.Equal(live.Subject, restored.Subject);
+        Assert.Equal(live.HasSubject, restored.HasSubject);
+        Assert.Equal(live.Notices, restored.Notices);
+        Assert.Equal(live.HasNotices, restored.HasNotices);
+        Assert.Equal(live.NoticesHeader, restored.NoticesHeader);
+        Assert.Equal(live.IsPartialPassage, restored.IsPartialPassage);
+        Assert.Equal(live.Usage, restored.Usage);
+        Assert.Equal(live.Elapsed, restored.Elapsed);
+        Assert.Equal(live.Footer, restored.Footer);
+        Assert.Equal(live.HasFooter, restored.HasFooter);
+        Assert.Equal(live.Status, restored.Status);
+        Assert.Equal(live.HasStatus, restored.HasStatus);
+        Assert.Equal(live.Failed, restored.Failed);
+        Assert.Equal(live.HasSent, restored.HasSent);
+        Assert.Equal(live.SentHeader, restored.SentHeader);
+        Assert.Equal(live.Sent!.SystemPrompt, restored.Sent!.SystemPrompt);
+        Assert.Equal(live.Sent.UserContent, restored.Sent.UserContent);
+        Assert.Equal(live.Sent.Fields, restored.Sent.Fields);
+        Assert.Equal(live.Sent.HasHistory, restored.Sent.HasHistory);
+
+        // The blocks exist only after PublishAnswer, which is the one step a restore can silently skip while
+        // every string assertion above still passes. The markup is there so the count is not trivially 1.
+        Assert.Equal(live.Blocks.Count, restored.Blocks.Count);
+        Assert.True(live.Blocks.Count > 0);
+
+        // A turn read off disk is never running, whatever the live one was doing.
+        Assert.False(restored.IsRunning);
+        Assert.False(live.IsRunning);
+    }
+
+    /// <summary>
+    /// At launch the panel reloads the conversation it was in. <b>[fsnow]</b>: <i>"Restore the last session
+    /// silently"</i> — so no model call, and nothing asked of the reader.
+    /// </summary>
+    [Fact]
+    public async Task The_last_conversation_is_restored_silently_at_launch()
+    {
+        var store = new FakeStore();
+        var state = new ApplicationState();
+
+        // Written by one launch...
+        var (first, _, _, _) = Panel(Answering(Said("An answer.")), store: store, state: state);
+        await first.AskAsync(AiTask.Explain);
+        await first.AskAsync(AiTask.Translate);
+        var written = store.LastSaved!;
+
+        // ...and read by the next, which finds it through the id application state kept.
+        store.ToLoad = written;
+        var model = new StubOrchestrator();
+        var (second, _, _, _) = Panel(model, store: store, state: state);
+
+        await second.RestoreAsync();
+
+        Assert.Equal(written.Id, store.AskedFor);
+        Assert.Equal(2, second.Turns.Count);
+        Assert.True(second.HasTurns);
+        Assert.Equal("An answer.", second.Turns[0].Answer);
+        Assert.Equal("", second.Status);
+
+        // Silently: restoring is not asking.
+        Assert.Empty(model.Requests);
+    }
+
+    /// <summary>
+    /// Construction alone restores nothing. The panel is built during the dock layout build, BEFORE
+    /// <c>LoadStateAsync</c> finishes, so a constructor that read the active id would read the default empty
+    /// state every launch — the sequencing that <c>SearchViewModel.ApplyState</c> (#87) and
+    /// <c>DictionaryViewModel.ApplyState</c> (#479) exist for.
+    /// </summary>
+    [Fact]
+    public void Construction_restores_nothing_because_state_may_not_be_loaded_yet()
+    {
+        var store = new FakeStore { ToLoad = new AiSession { Id = "kept", Turns = { new AiTurnRecord() } } };
+        var (vm, _, _, _) = Panel(new StubOrchestrator(), store: store,
+            state: new ApplicationState { ActiveAssistantSessionId = "kept" });
+
+        Assert.Empty(vm.Turns);
+        Assert.Null(store.AskedFor);
+    }
+
+    /// <summary>
+    /// A follow-up asked after a restart continues the conversation. The restored turns replay their MARKED
+    /// answers — the form the model wrote, markers and all (#991) — and the question lines they were stored
+    /// with rather than lines re-composed from today's wording.
+    /// </summary>
+    [Fact]
+    public async Task A_follow_up_after_a_restart_replays_the_restored_conversation()
+    {
+        var store = new FakeStore();
+        var state = new ApplicationState();
+
+        var (first, _, _, _) = Panel(
+            AnsweringFrom(
+                ContextFrom(),
+                AiTurnEvent.ForText("The term appamada matters.", "The term [[appamada]] matters.")),
+            store: store, state: state);
+        await first.AskAsync(AiTask.Explain);
+
+        var written = store.LastSaved!;
+        var askedLine = written.Turns[0].AskedLine;
+        store.ToLoad = written;
+
+        var next = AnsweringFrom(ContextFrom(), Said("It means vigilance."));
+        var (second, _, _, _) = Panel(next, store: store, state: state);
+        await second.RestoreAsync();
+
+        second.Question = "what does the second word mean?";
+        await second.AskAsync(AiTask.Ask);
+
+        var replayed = Assert.Single(next.Requests[0].History!);
+
+        // The marked form, not the text on screen: the system prompt asks for those markers on every Pāli span,
+        // and replaying the stripped answer shows the model a transcript of itself disobeying.
+        Assert.Equal("The term [[appamada]] matters.", replayed.Answer);
+
+        // And the question line as it was STORED. Re-rendering it would mean that changing the wording of
+        // DescribeAsked silently altered what every reopened conversation claims it was asked.
+        Assert.Equal(askedLine, replayed.Question);
+
+        // The new turn's own record points back at the restored one rather than copying it.
+        Assert.Equal(new[] { written.Turns[0].Id }, store.LastSaved!.Turns[1].Sent!.ReplayedTurnIds);
+    }
+
+    /// <summary>
+    /// A restored turn's Sent block shows the conversation it was sent with, rebuilt from the ids it stored —
+    /// which is what makes storing the history by reference rather than by value cost nothing on screen.
+    /// </summary>
+    [Fact]
+    public async Task A_restored_turn_shows_the_conversation_it_was_sent_with()
+    {
+        var store = new FakeStore();
+        var state = new ApplicationState();
+
+        var (first, _, _, _) = Panel(AnsweringFrom(ContextFrom(), Said("An answer.")),
+            store: store, state: state);
+        await first.AskAsync(AiTask.Explain);
+        await first.AskAsync(AiTask.Translate);
+
+        var written = store.LastSaved!;
+        store.ToLoad = written;
+        var (second, _, _, _) = Panel(new StubOrchestrator(), store: store, state: state);
+        await second.RestoreAsync();
+
+        // The first turn sent no conversation; the second sent the first.
+        Assert.False(second.Turns[0].Sent!.HasHistory);
+
+        var history = second.Turns[1].Sent!.History!;
+        Assert.Equal(2, history.Count);
+        Assert.Equal(ChatRole.User, history[0].Role);
+        Assert.Equal(written.Turns[0].AskedLine, history[0].Content);
+        Assert.Equal(ChatRole.Assistant, history[1].Role);
+        Assert.Equal("An answer.", history[1].Content);
+    }
+
+    /// <summary>An id pointing at a turn that is no longer in the session is skipped, not refused. A turn
+    /// deleted from a file by hand leaves one, and losing the conversation over it would be the worse
+    /// failure.</summary>
+    [Fact]
+    public void A_dangling_replayed_turn_id_is_skipped()
+    {
+        var session = new AiSession
+        {
+            Id = "kept",
+            Turns =
+            {
+                new AiTurnRecord
+                {
+                    Id = "second",
+                    Answer = "An answer.",
+                    Sent = new AiSentRecord
+                    {
+                        SystemPrompt = "sys",
+                        UserContent = "user",
+                        ReplayedTurnIds = { "a-turn-that-was-deleted" },
+                    },
+                },
+            },
+        };
+
+        var byId = session.Turns.ToDictionary(t => t.Id, StringComparer.Ordinal);
+        var restored = AiTurnViewModel.FromRecord(session.Turns[0], byId);
+
+        Assert.False(restored.Sent!.HasHistory);
+        Assert.Equal("An answer.", restored.Answer);
+    }
+
+    /// <summary>
+    /// A session file that could not be read leaves an empty panel and one sentence saying where it was kept.
+    /// Never a crash, and never a quiet deletion — the reader's transcript is still on disk.
+    /// </summary>
+    [Fact]
+    public async Task An_unreadable_conversation_leaves_an_empty_panel_and_says_where_it_went()
+    {
+        var store = new FakeStore
+        {
+            ToLoad = null,
+            ReportOnLoad = new AiSessionUnreadable("kept", "/kept/kept.unreadable-1.json", "unexpected token"),
+        };
+        var (vm, _, _, _) = Panel(new StubOrchestrator(), store: store,
+            state: new ApplicationState { ActiveAssistantSessionId = "kept" });
+
+        await vm.RestoreAsync();
+
+        Assert.Empty(vm.Turns);
+        Assert.Contains("could not be read", vm.Status);
+        Assert.Contains("/kept/kept.unreadable-1.json", vm.Status);
+    }
+
+    /// <summary>An id naming a session that is no longer there is not an error — a hand-deleted file leaves one,
+    /// and the panel simply starts empty.</summary>
+    [Fact]
+    public async Task A_missing_conversation_is_not_an_error()
+    {
+        var (vm, _, _, _) = Panel(new StubOrchestrator(),
+            store: new FakeStore { ToLoad = null },
+            state: new ApplicationState { ActiveAssistantSessionId = "gone" });
+
+        await vm.RestoreAsync();
+
+        Assert.Empty(vm.Turns);
+        Assert.Equal("", vm.Status);
+    }
+
+    /// <summary>Nothing to restore, nothing read: a first-ever launch must not ask the store for anything.</summary>
+    [Fact]
+    public async Task With_no_active_conversation_nothing_is_read()
+    {
+        var (vm, store, _, _) = Panel(new StubOrchestrator());
+
+        await vm.RestoreAsync();
+
+        Assert.Null(store.AskedFor);
+        Assert.Empty(vm.Turns);
+    }
+
+    /// <summary>A restored conversation keeps being added to rather than replaced — the next turn appends to the
+    /// same file.</summary>
+    [Fact]
+    public async Task A_turn_after_a_restore_is_appended_to_the_conversation_it_reopened()
+    {
+        var store = new FakeStore();
+        var state = new ApplicationState();
+
+        var (first, _, _, _) = Panel(Answering(Said("An answer.")), store: store, state: state);
+        await first.AskAsync(AiTask.Explain);
+        var written = store.LastSaved!;
+
+        store.ToLoad = written;
+        var (second, _, _, _) = Panel(Answering(Said("Another answer.")), store: store, state: state);
+        await second.RestoreAsync();
+        await second.AskAsync(AiTask.Translate);
+
+        Assert.Equal(written.Id, store.LastSaved!.Id);
+        Assert.Equal(2, store.LastSaved.Turns.Count);
+        Assert.Equal(2, second.Turns.Count);
+    }
+
+    // ---- New conversation ------------------------------------------------------------------------
+
+    /// <summary>
+    /// <b>[fsnow]</b>: <i>"'Clear' was introduced by Claude at some point and is not relevant. I would like to
+    /// create new conversations like in Claude Code, maybe also with a plus button, while saving the current
+    /// one."</i>
+    ///
+    /// <para>Nothing is saved here because nothing is left to save — the conversation was written at its last
+    /// turn. What this does is let go: the transcript, the session, and the id that would otherwise reopen
+    /// it.</para>
+    /// </summary>
+    [Fact]
+    public async Task A_new_conversation_lets_go_of_the_one_that_was_already_saved()
+    {
+        var (vm, store, state, _) = Panel(Answering(Said("An answer.")));
+
+        await vm.AskAsync(AiTask.Explain);
+        var savesBefore = store.Saves.Count;
+        var firstId = store.LastSaved!.Id;
+
+        vm.NewConversationCommand.Execute().Subscribe();
+
+        Assert.Empty(vm.Turns);
+        Assert.False(vm.HasTurns);
+        Assert.Null(vm.LastTurn);
+        Assert.Equal("", vm.Status);
+
+        // Nothing written, and nothing lost: the transcript on disk is untouched.
+        Assert.Equal(savesBefore, store.Saves.Count);
+        Assert.Null(state.ActiveAssistantSessionId);
+
+        // The next turn starts a different conversation, in its own file, and nothing of the old one is replayed
+        // to the model.
+        await vm.AskAsync(AiTask.Translate);
+        Assert.NotEqual(firstId, store.LastSaved!.Id);
+        Assert.Single(store.LastSaved.Turns);
+        Assert.Equal(store.LastSaved.Id, state.ActiveAssistantSessionId);
+    }
+
+    /// <summary>
+    /// Blocked while a turn runs, like every other command. Letting go of a session mid-stream would leave that
+    /// turn's save writing into a conversation the panel no longer shows.
+    /// </summary>
+    [Fact]
+    public async Task A_new_conversation_is_refused_while_a_turn_is_running()
+    {
+        var orchestrator = new BlockingOrchestrator();
+        var (vm, store, state, _) = Panel(orchestrator);
+
+        var pending = vm.AskAsync(AiTask.Explain);
+        Assert.True(vm.IsBusy);
+
+        vm.NewConversationCommand.Execute().Subscribe();
+
+        // Refused outright: the turn is still on screen and still running.
+        Assert.Single(vm.Turns);
+        Assert.True(vm.Turns[0].IsRunning);
+
+        orchestrator.Gate.SetResult();
+        await pending;
+
+        // And it was saved into a conversation that still exists.
+        Assert.Single(store.LastSaved!.Turns);
+        Assert.Equal(store.LastSaved.Id, state.ActiveAssistantSessionId);
+    }
+}

--- a/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
+++ b/src/CST.Avalonia.Tests/ViewModels/AiAssistantViewModelTests.cs
@@ -26,7 +26,7 @@ namespace CST.Avalonia.Tests.ViewModels;
 /// </summary>
 public class AiAssistantViewModelTests
 {
-    private sealed class StubOrchestrator : IAiChatOrchestrator
+    internal sealed class StubOrchestrator : IAiChatOrchestrator
     {
         internal List<AiTurnEvent> Events { get; } = new();
         internal int StopCalls { get; private set; }
@@ -51,7 +51,7 @@ public class AiAssistantViewModelTests
         public void Stop() => StopCalls++;
     }
 
-    private sealed class StubReaderState : IReaderStateService
+    internal sealed class StubReaderState : IReaderStateService
     {
         internal ReaderStateResult Result { get; set; } =
             ReaderStateResult.Ok(new ReaderState("s0101m.mul.xml", 12, null));
@@ -79,17 +79,17 @@ public class AiAssistantViewModelTests
         }
     }
 
-    private static CitationRef Citation() =>
+    internal static CitationRef Citation() =>
         new("s0101m.mul.xml", "Sīlakkhandhavaggapāḷi", "para 12", Array.Empty<SnippetPageRef>());
 
-    private static AiTurnContext Context(params string[] notices) => Context(false, notices);
+    internal static AiTurnContext Context(params string[] notices) => Context(false, notices);
 
-    private static AiTurnContext Context(bool passageTrimmed, params string[] notices) =>
+    internal static AiTurnContext Context(bool passageTrimmed, params string[] notices) =>
         new(AiTask.Explain, "English", Citation(),
             new BookContext("s0101m.mul.xml", "Sīlakkhandhavaggapāḷi", CST.Pitaka.Sutta, CST.CommentaryLevel.Mula),
             notices, passageTrimmed);
 
-    private static AiTurnContext ContextWithSent(SentContext sent) =>
+    internal static AiTurnContext ContextWithSent(SentContext sent) =>
         new(AiTask.Explain, "English", Citation(),
             new BookContext("s0101m.mul.xml", "Sīlakkhandhavaggapāḷi", CST.Pitaka.Sutta, CST.CommentaryLevel.Mula),
             Array.Empty<string>(), false, sent);
@@ -978,10 +978,10 @@ public class AiAssistantViewModelTests
 
     /// <summary>One text delta with both halves, as the orchestrator emits them for text carrying no
     /// markers — the stripped form and the model's own form are the same string.</summary>
-    private static AiTurnEvent Said(string text) => AiTurnEvent.ForText(text, text);
+    internal static AiTurnEvent Said(string text) => AiTurnEvent.ForText(text, text);
 
     /// <summary>A stub that answers every turn the same way: citation, some text, done.</summary>
-    private static StubOrchestrator Answering(params AiTurnEvent[] middle)
+    internal static StubOrchestrator Answering(params AiTurnEvent[] middle)
     {
         var orchestrator = new StubOrchestrator();
         orchestrator.Events.Add(AiTurnEvent.ForStarted(Context()));

--- a/src/CST.Avalonia/App.axaml.cs
+++ b/src/CST.Avalonia/App.axaml.cs
@@ -1061,6 +1061,24 @@ public partial class App : Application
             dictionaryViewModel?.ApplyState();
         });
 
+        // And the Assistant panel: reload the conversation it was in. [fsnow]: "Restore the last session
+        // silently" — no model call, the way books and reading positions are restored. Same sequencing story as
+        // the two panels above (the VM is built during the layout build, before this load finishes), so the
+        // restore is pushed here rather than done in its constructor. (#849)
+        //
+        // Gated on the assistant being switched on, because resolving the VM CREATES it: a reader with the
+        // feature off would otherwise get a panel constructed, an environment-key probe subscribed to, and a
+        // readiness check run, for a tool that is not in the layout. (CstDockFactory.CreateLayout resolves it
+        // only when enabled, for the same reason.)
+        if (CstDockFactory.AssistantEnabled())
+        {
+            await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                var assistant = ServiceProvider?.GetService<AiAssistantViewModel>();
+                if (assistant != null) await assistant.RestoreAsync();
+            });
+        }
+
         // #44: the recent-books menu reads the (now-loaded) persisted MRU list; refresh it so the saved list
         // shows on launch even if the window's menu was registered before this load finished.
         Dispatcher.UIThread.Post(RebuildRecentMenus);
@@ -1704,7 +1722,12 @@ public partial class App : Application
             sp.GetService<Services.Ai.IChatProviderResolver>(),
             sp.GetService<ISettingsService>(),
             sp.GetService<Services.Ai.IAiConnectionService>(),
-            sp.GetService<Services.Ai.Credentials.IAiEnvironmentKeys>()));
+            sp.GetService<Services.Ai.Credentials.IAiEnvironmentKeys>(),
+            // The transcript store and the one line of application state that names the active conversation.
+            // The panel writes a session at the end of every turn and reloads the last one at launch — see
+            // AiAssistantViewModel.RestoreAsync, which InitializeFromLoadedState calls once state is in. (#849)
+            sp.GetService<Services.Ai.IAiSessionStore>(),
+            sp.GetService<IApplicationStateService>()));
         // services.AddTransient<MainWindowViewModel>();
     }
 

--- a/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
+++ b/src/CST.Avalonia/Services/Ai/AiChatOrchestrator.cs
@@ -301,7 +301,11 @@ public sealed class AiChatOrchestrator : IAiChatOrchestrator
 
         yield return AiTurnEvent.ForStarted(new AiTurnContext(
             bundle.Task, bundle.OutputLanguage, bundle.Citation, bundle.Book, prompt.Notices, passageTrimmed,
-            Describe(bundle, prompt, provider, replayed)));
+            Describe(bundle, prompt, provider, replayed),
+            // Structured as well as printed in the Sent block. A stored turn has to say which model answered
+            // it (#849), and the alternative — the panel matching a SentField by its English label — is the
+            // same mistake as deriving the partial-passage flag from a notice's wording.
+            provider.Provider.Id, provider.Model));
 
         // ---- Stream. The conversation, then this turn. This turn's message goes LAST and carries the full
         // rendered prompt, so the passage the model is being asked about is the last thing it reads.

--- a/src/CST.Avalonia/Services/Ai/AiTurn.cs
+++ b/src/CST.Avalonia/Services/Ai/AiTurn.cs
@@ -110,6 +110,19 @@ public enum AiTurnEventKind
 /// by keyword-matching prose also fails the rule the rest of this contract keeps: what the user sees beside an
 /// answer is built from bundle data, never parsed out of text. Notices are for reading; this is for deciding.</para>
 /// </param>
+/// <param name="ProviderId">
+/// Which connection answered. (#849)
+///
+/// <para><b>Structured, beside the line <see cref="Sent"/> already prints.</b> A stored turn has to name the
+/// model that produced it — an answer is not attributable without one, and a conversation spanning a model
+/// change is the ordinary case rather than a corner of it. The id is in <c>Sent.Fields</c> too, but as a
+/// display row: recovering it from there would mean matching a field by its English label, which is the same
+/// mistake as reading the partial-passage flag out of a notice's wording.</para>
+///
+/// <para>Null only where a caller assembles a context without a resolved provider, which the orchestrator
+/// never does.</para>
+/// </param>
+/// <param name="ModelId">Which model, as the reader configured it — see <paramref name="ProviderId"/>.</param>
 public sealed record AiTurnContext(
     AiTask Task,
     string OutputLanguage,
@@ -117,7 +130,9 @@ public sealed record AiTurnContext(
     BookContext Book,
     IReadOnlyList<string> Notices,
     bool PassageTrimmed,
-    SentContext? Sent = null);
+    SentContext? Sent = null,
+    string? ProviderId = null,
+    string? ModelId = null);
 
 /// <summary>
 /// Everything the turn actually sent, for the reader to look at. (#665)

--- a/src/CST.Avalonia/Services/Ai/ReaderState.cs
+++ b/src/CST.Avalonia/Services/Ai/ReaderState.cs
@@ -52,12 +52,33 @@ public enum ReaderStateProblem
 /// or when the anchor cache could not place it — the caller then falls back to
 /// <paramref name="Paragraph"/>.</para>
 /// </param>
+/// <param name="ReadingPosition">
+/// Where the reader was standing, as #434's two-anchor token — the position an Assistant turn stores so it can
+/// later be taken back to it. (#849)
+///
+/// <para><b>[fsnow]</b>: <i>"The Assistant's memory should carry the same scroll context saved elsewhere: two
+/// anchors and a fraction between them."</i> So this is the app's own persisted representation, not a second
+/// one — and it is not redundant with the citation a turn also stores: the citation is where the answer
+/// points, this is where the reader was.</para>
+///
+/// <para><b>[observed] Read from the book view model's rolling capture, not from the WebView.</b>
+/// <c>BookDisplayViewModel.LastPositionToken</c> is refreshed from the view's ~200 ms status tick and is
+/// already what <c>CstDockFactory</c> persists per book window at shutdown. Reading it is a field access on
+/// the UI thread; asking the WebView for a fresh token is a JS round trip that shares a lock with the status
+/// pipeline and can time out. <b>The fidelity trade is up to one tick of staleness</b> — the reader could have
+/// scrolled in the last fifth of a second — which is smaller than the trade a live round trip makes by
+/// occasionally returning nothing at all.</para>
+///
+/// <para>Null before the anchor cache has built, which is the same case the store already documents as "not
+/// captured": a turn is worth keeping without one.</para>
+/// </param>
 public sealed record ReaderState(
     string BookId,
     int Paragraph,
     string? SelectionText,
     bool SelectionUnavailable = false,
-    int? SelectionParagraph = null);
+    int? SelectionParagraph = null,
+    Models.ReadingPositionToken? ReadingPosition = null);
 
 /// <summary>
 /// Whether the caller can say which book window the reader means. (#938)
@@ -269,7 +290,14 @@ public sealed class ReaderStateService : IReaderStateService
             return (ReaderStateResult.Fail(ReaderStateProblem.PositionUnknown), null);
         }
 
-        return (ReaderStateResult.Ok(new ReaderState(document.Book.FileName, paragraph, SelectionText: null)),
+        return (ReaderStateResult.Ok(new ReaderState(
+                    document.Book.FileName,
+                    paragraph,
+                    SelectionText: null,
+                    // The rolling #434 token the view pushes here every status tick — the same value the dock
+                    // factory persists per book window. Taken on this thread rather than by a fresh WebView
+                    // round trip: see the note on the parameter. (#849)
+                    ReadingPosition: document.LastPositionToken)),
                 document);
     }
 

--- a/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiAssistantViewModel.cs
@@ -46,6 +46,27 @@ namespace CST.Avalonia.ViewModels;
 /// was a transcript to the reader and a series of unrelated requests to the model until #991, which is why
 /// "what did you mean by the third word?" used to answer about nothing.
 /// </para>
+///
+/// <para>
+/// <b>And it persists.</b> The panel owns one <see cref="AiSession"/> at a time: it is created at the first
+/// turn that ends, rewritten in full at the end of every turn after that, and reloaded at the next launch —
+/// <b>[fsnow]</b>: <i>"Restore the last session silently"</i>, the way books and reading positions are
+/// restored, with no model call. <c>ApplicationState.ActiveAssistantSessionId</c> is the one thing
+/// application state keeps; the transcripts live one file each (#849).
+/// </para>
+///
+/// <para>
+/// <b>A failed save never fails a turn.</b> The store answers false rather than throwing, and the worst this
+/// panel does about it is put one sentence in <see cref="Status"/>. The answer is on screen and the reader is
+/// reading it; losing it to an error dialog about a file would be the larger harm.
+/// </para>
+///
+/// <para>
+/// <b>There is no Clear.</b> <b>[fsnow]</b>: <i>"'Clear' was introduced by Claude at some point and is not
+/// relevant. I would like to create new conversations like in Claude Code, maybe also with a plus button,
+/// while saving the current one."</i> So the command is <see cref="NewConversationCommand"/>, and nothing is
+/// destroyed by it — the conversation it leaves behind was already written at its last turn.
+/// </para>
 /// </summary>
 public class AiAssistantViewModel : ReactiveTool
 {
@@ -53,7 +74,18 @@ public class AiAssistantViewModel : ReactiveTool
     private readonly IReaderStateService? _readerState;
     private readonly IChatProviderResolver? _resolver;
     private readonly ISettingsService? _settings;
+    private readonly IAiSessionStore? _store;
+    private readonly IApplicationStateService? _appState;
     private readonly ILogger _logger = Log.ForContext<AiAssistantViewModel>();
+
+    /// <summary>
+    /// The conversation being added to, or null when the panel is fresh. (#849)
+    ///
+    /// <para>Created lazily, at the first turn that ENDS rather than at the first that starts: a session whose
+    /// only turn was refused before it reached the model would be a file recording something the reader did not
+    /// do, and the refusals above <c>StartTurn</c> never create a turn at all.</para>
+    /// </summary>
+    private AiSession? _session;
 
     /// <summary>
     /// How often streamed text reaches the screen. Fast enough to read as live, slow enough that a fast stream
@@ -86,12 +118,23 @@ public class AiAssistantViewModel : ReactiveTool
         IChatProviderResolver? resolver,
         ISettingsService? settings,
         IAiConnectionService? connections = null,
-        Services.Ai.Credentials.IAiEnvironmentKeys? environmentKeys = null)
+        Services.Ai.Credentials.IAiEnvironmentKeys? environmentKeys = null,
+        // Optional like everything above, and for the same reason: a panel with no store is a panel that
+        // forgets, not a panel that fails. (#849)
+        IAiSessionStore? store = null,
+        IApplicationStateService? appState = null)
     {
         _orchestrator = orchestrator;
         _readerState = readerState;
         _resolver = resolver;
         _settings = settings;
+        _store = store;
+        _appState = appState;
+
+        // Before anything is loaded, as the store's contract asks. An unreadable transcript is the one failure
+        // the reader has to be told about — it has been kept aside rather than deleted, and the log alone
+        // leaves them with an empty panel and no explanation.
+        if (_store is not null) _store.Unreadable += OnSessionUnreadable;
 
         // Changing model is the reason the provider rework exists, so it belongs here rather than in
         // Settings (#693). Readiness is re-asked on every switch: picking a model on a connection with no
@@ -122,7 +165,7 @@ public class AiAssistantViewModel : ReactiveTool
         // that Retry no longer writes to the question box.
         RetryCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel?>(RetryAsync);
         CopyCommand = ReactiveCommand.CreateFromTask<AiTurnViewModel>(CopyAsync);
-        ClearCommand = ReactiveCommand.Create(Clear);
+        NewConversationCommand = ReactiveCommand.Create(NewConversation);
 
         // An unhandled exception in a ReactiveCommand goes to RxApp.DefaultExceptionHandler, which
         // TERMINATES THE APP. Everything these commands call catches internally today, so no failing case is
@@ -135,7 +178,7 @@ public class AiAssistantViewModel : ReactiveTool
         foreach (var command in new IHandleObservableErrors[]
                  {
                      ExplainCommand, TranslateCommand, GrammarCommand, WordByWordCommand, AskQuestionCommand,
-                     StopCommand, RefreshReadinessCommand, RetryCommand, CopyCommand, ClearCommand,
+                     StopCommand, RefreshReadinessCommand, RetryCommand, CopyCommand, NewConversationCommand,
                  })
         {
             command.ThrownExceptions.Subscribe(ex =>
@@ -187,7 +230,23 @@ public class AiAssistantViewModel : ReactiveTool
     /// <summary>Copies one turn's answer. Explicit rather than left to drag-select, which stopped covering
     /// the whole answer once tables put each cell in its own control.</summary>
     public ReactiveCommand<AiTurnViewModel, Unit> CopyCommand { get; }
-    public ReactiveCommand<Unit, Unit> ClearCommand { get; }
+
+    /// <summary>
+    /// Start a new conversation, keeping the one on screen. (#849, #850)
+    ///
+    /// <para><b>[fsnow]</b>: <i>"'Clear' was introduced by Claude at some point and is not relevant. I would
+    /// like to create new conversations like in Claude Code, maybe also with a plus button, while saving the
+    /// current one."</i></para>
+    ///
+    /// <para><b>It saves nothing, because there is nothing left to save.</b> Every turn was written when it
+    /// ended, so this only lets go: the transcript clears, the session reference drops, and the active id in
+    /// application state is cleared so the next launch restores an empty panel rather than the conversation the
+    /// reader had just set aside. Nothing is destroyed, so it asks nothing.</para>
+    ///
+    /// <para>Guarded by <see cref="IsBusy"/> like every other command: letting go of a session whose turn is
+    /// still streaming would leave that turn's save writing to a conversation the panel no longer shows.</para>
+    /// </summary>
+    public ReactiveCommand<Unit, Unit> NewConversationCommand { get; }
 
     /// <summary>Re-ask the resolver whether the assistant is configured. Bound to the panel's own refresh, so
     /// a reader who has just been sent to Settings can come back and see the answer change.</summary>
@@ -374,7 +433,12 @@ public class AiAssistantViewModel : ReactiveTool
         // the box — the box now holds unsent drafts, and those are precious.
         var typed = questionOverride ?? Question;
         var question = string.IsNullOrWhiteSpace(typed) ? null : typed.Trim();
-        var turn = StartTurn(task, question, state.SelectionText, clearBox: questionOverride is null);
+        var turn = StartTurn(
+            task, question, state.SelectionText, clearBox: questionOverride is null,
+            // Where the reader was standing when they asked, captured at the START of the turn rather than at
+            // its end: by the time an answer arrives they may have scrolled on, and the position a stored turn
+            // is asking to be taken back to is the one it was asked from. (#849)
+            readingPosition: state.ReadingPosition);
 
         try
         {
@@ -416,6 +480,12 @@ public class AiAssistantViewModel : ReactiveTool
         finally
         {
             EndTurn(turn);
+
+            // Written here, after the turn is closed, so the record holds the final status, the final elapsed
+            // figure and whatever text stood when it stopped. Awaited rather than fired and forgotten: the
+            // caller's IsBusy is still true, which is what keeps a new conversation from being started out from
+            // under the write. (#849)
+            await SaveTurnAsync(turn);
         }
     }
 
@@ -445,11 +515,23 @@ public class AiAssistantViewModel : ReactiveTool
         await clipboard.SetTextAsync(turn.CopyText);
     }
 
-    private void Clear()
+    /// <inheritdoc cref="NewConversationCommand"/>
+    private void NewConversation()
     {
         if (IsBusy) return;
+
         Turns.Clear();
         this.RaisePropertyChanged(nameof(HasTurns));
+        this.RaisePropertyChanged(nameof(LastTurn));
+
+        _session = null;
+
+        if (_appState is not null)
+        {
+            _appState.Current.ActiveAssistantSessionId = null;
+            _appState.MarkDirty();
+        }
+
         Status = "";
     }
 
@@ -462,6 +544,14 @@ public class AiAssistantViewModel : ReactiveTool
                 // while the model is still thinking.
                 turn.Citation = Describe(context.Citation);
                 turn.CitationDetail = DescribeCitationDetail(context.Citation);
+                // And the citation ITSELF, not only the two lines drawn from it. This event was the only place
+                // it ever appeared and the panel used to drop it here, which left a stored turn readable and
+                // unnavigable — nothing in "Mahāvaggapāḷi — para 12" names a file to reopen. (#849)
+                turn.StructuredCitation = context.Citation;
+                // Which model answered. Structured for the same reason (#849): recovering it from the Sent
+                // block would mean matching a field by its English label.
+                turn.ProviderId = context.ProviderId;
+                turn.ModelId = context.ModelId;
                 turn.Notices.Clear();
                 foreach (var notice in context.Notices) turn.Notices.Add(notice);
                 turn.RaiseNoticesChanged();
@@ -510,6 +600,10 @@ public class AiAssistantViewModel : ReactiveTool
 
             case AiTurnEventKind.Usage when e.Usage is { } usage:
                 turn.Usage = FormatUsage(usage);
+                // The report as well as the line printed from it: the line has been through :N0, so the same
+                // turn reads 1,024 or 1.024 depending on the machine that stored it, and no arithmetic can be
+                // done on it afterwards. (#849)
+                turn.UsageReport = usage;
                 break;
 
             case AiTurnEventKind.Error when e.Error is { } error:
@@ -546,7 +640,9 @@ public class AiAssistantViewModel : ReactiveTool
         _orchestrator?.Stop();
     }
 
-    private AiTurnViewModel StartTurn(AiTask task, string? question, string? selection, bool clearBox)
+    private AiTurnViewModel StartTurn(
+        AiTask task, string? question, string? selection, bool clearBox,
+        Models.ReadingPositionToken? readingPosition = null)
     {
         var turn = new AiTurnViewModel(task, question)
         {
@@ -554,6 +650,7 @@ public class AiAssistantViewModel : ReactiveTool
             // forgotten — is visible immediately rather than discovered in the answer.
             Subject = Summarize(selection),
             Status = "Contacting the provider…",
+            ReadingPosition = readingPosition,
         };
 
         Turns.Add(turn);
@@ -596,6 +693,7 @@ public class AiAssistantViewModel : ReactiveTool
     private void Tick(AiTurnViewModel turn)
     {
         Flush(turn);
+        turn.ElapsedTime = _elapsed.Elapsed;
         turn.Elapsed = FormatElapsed(_elapsed.Elapsed);
 
         // The tick owns the status line only while nothing real has arrived, and surrenders it the instant
@@ -647,10 +745,179 @@ public class AiAssistantViewModel : ReactiveTool
         _flushTimer = null;
         _elapsed.Stop();
         Flush(turn);
+        // The duration as well as the line printed from it — the stopwatch is restarted by the next turn, so
+        // after this the turn itself is the only thing that still knows. (#849)
+        turn.ElapsedTime = _elapsed.Elapsed;
         turn.Elapsed = FormatElapsed(_elapsed.Elapsed);
         turn.IsRunning = false;
         _current = null;
     }
+
+    // ---- Persistence (#849) ----------------------------------------------------------------------
+
+    /// <summary>
+    /// Write the conversation, including the turn that has just ended.
+    ///
+    /// <para><b>The whole session, every turn</b> — not an append. The turn that ended is not the only thing
+    /// that changed about the file: <c>LastActive</c> moved, and on the first turn the name was set. A
+    /// whole-file replace is also the only version of this that cannot leave unreadable JSON behind.</para>
+    ///
+    /// <para><b>A failure is a sentence, never an exception.</b> The store answers false; the answer is on
+    /// screen either way, and the reader is reading it. What they are told is that the conversation will not be
+    /// there next time — which is the part they can act on, by copying the answer.</para>
+    /// </summary>
+    private async Task SaveTurnAsync(AiTurnViewModel turn)
+    {
+        if (_store is null) return;
+
+        try
+        {
+            var session = _session ??= CreateSession(turn);
+
+            session.Turns.Add(turn.ToRecord());
+            session.LastActive = DateTimeOffset.Now;
+
+            // Deliberately NOT the turn's cancellation token. A stopped turn is exactly the one whose partial
+            // answer most needs keeping, and handing the save the token the reader has just cancelled would
+            // abandon the write that was supposed to keep it.
+            if (await _store.SaveAsync(session))
+                return;
+
+            // The store has already logged why. What is left to say is what it means for the reader.
+            Status = "That answer could not be saved, so this conversation will not reopen next time.";
+        }
+        catch (Exception ex)
+        {
+            // The store promises not to throw; this catch is for the mapping above it, and the rule is the same
+            // either way — a turn the reader can read must not be lost to a problem with a file.
+            _logger.Error(ex, "Could not record the assistant turn");
+            Status = "That answer could not be saved, so this conversation will not reopen next time.";
+        }
+    }
+
+    /// <summary>
+    /// The session this panel is now adding to, named from the turn that created it.
+    ///
+    /// <para><b>[fsnow]</b> chose <i>"Auto from the first turn, renamable"</i> — so the name is composed here,
+    /// once, and never by a model. A preset turn is named for what was asked and where (<c>Explain ·
+    /// Mahāvaggapāḷi para 12</c>); a question is named by its own first words, because that is what the reader
+    /// will recognise in a list and the preset label would be the same on every one of them.</para>
+    /// </summary>
+    private AiSession CreateSession(AiTurnViewModel turn)
+    {
+        var now = DateTimeOffset.Now;
+        var session = new AiSession
+        {
+            Id = AiSession.NewId(),
+            Name = NameFor(turn),
+            Created = now,
+            LastActive = now,
+        };
+
+        if (_appState is not null)
+        {
+            // The one thing application state keeps, so the next launch knows which file to reopen. Dirtied
+            // rather than saved: the state service owns when it writes.
+            _appState.Current.ActiveAssistantSessionId = session.Id;
+            _appState.MarkDirty();
+        }
+
+        return session;
+    }
+
+    /// <summary>The auto-name. <b>[fsnow]</b>: <i>"Auto from the first turn, renamable"</i>.</summary>
+    internal static string NameFor(AiTurnViewModel turn)
+    {
+        // A question names itself. Its first words are what distinguishes it from the next question about the
+        // same passage, which the preset label and citation would not.
+        if (turn.Task == AiTask.Ask && !string.IsNullOrWhiteSpace(turn.Question))
+            return Shorten(turn.Question!, 60);
+
+        var citation = turn.Citation;
+        return string.IsNullOrWhiteSpace(citation)
+            // No citation to name it by — a turn that failed before the context was assembled. The preset alone
+            // is a poor name and still better than an empty row; a rename is one gesture away.
+            ? turn.PresetLabel
+            : $"{turn.PresetLabel} · {citation}";
+    }
+
+    /// <summary>
+    /// The first <paramref name="max"/> characters, whitespace collapsed, with an ellipsis where there was more.
+    /// Cut at the end rather than elided in the middle, unlike <see cref="Summarize"/>: a name is read from its
+    /// start, and a list of names sharing a prefix is the case the reader is scanning for.
+    /// </summary>
+    private static string Shorten(string text, int max)
+    {
+        var collapsed = System.Text.RegularExpressions.Regex.Replace(text.Trim(), @"\s+", " ");
+        return collapsed.Length <= max ? collapsed : $"{collapsed[..max].TrimEnd()}…";
+    }
+
+    /// <summary>
+    /// Reload the last conversation, silently. <b>[fsnow]</b>: <i>"Restore the last session silently"</i>.
+    ///
+    /// <para><b>Called by the app after application state has loaded, not from the constructor.</b> The panel is
+    /// built during the dock layout build, which runs BEFORE <c>LoadStateAsync</c> completes — so a constructor
+    /// reading <c>ActiveAssistantSessionId</c> would read the default empty state and restore nothing, every
+    /// time. The same sequencing <c>SearchViewModel.ApplyState</c> (#87) and <c>DictionaryViewModel.ApplyState</c>
+    /// (#479) exist for.</para>
+    ///
+    /// <para>Idempotent, and it never overwrites a conversation in progress: a panel that already has turns has
+    /// been used, and this is a launch-time restore rather than a switch (that is P3's).</para>
+    /// </summary>
+    public async Task RestoreAsync(CancellationToken ct = default)
+    {
+        if (_store is null || _appState is null) return;
+        if (_session is not null || Turns.Count > 0) return;
+
+        var id = _appState.Current.ActiveAssistantSessionId;
+        if (string.IsNullOrEmpty(id)) return;
+
+        AiSession? session;
+        try
+        {
+            session = await _store.LoadAsync(id, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // The store does not throw for a bad file; anything here is a defect, and a defect must still not
+            // be the reason the panel will not open.
+            _logger.Error(ex, "Could not restore the assistant session {Id}", id);
+            return;
+        }
+
+        // Null is both "there is no such file" and "it could not be read". The panel does the same thing for
+        // each — start empty — and only the second has anything to say, which Unreadable has already said.
+        if (session is null) return;
+
+        _session = session;
+
+        // By id, so a turn's replayed-history can be rebuilt from the ids it stored rather than from copies of
+        // earlier answers. Built over the whole session first: the references point backwards today, and a
+        // restore that depended on that would break the day compaction reorders anything.
+        var byId = new Dictionary<string, AiTurnRecord>(StringComparer.Ordinal);
+        foreach (var record in session.Turns)
+            byId[record.Id] = record;
+
+        foreach (var record in session.Turns)
+            Turns.Add(AiTurnViewModel.FromRecord(record, byId));
+
+        this.RaisePropertyChanged(nameof(HasTurns));
+        this.RaisePropertyChanged(nameof(LastTurn));
+
+        _logger.Information(
+            "Restored assistant session {Id} with {Count} turn(s)", session.Id, session.Turns.Count);
+    }
+
+    /// <summary>
+    /// A transcript that could not be read. It has been kept aside, not deleted, and this is the only place the
+    /// reader learns either fact.
+    /// </summary>
+    private void OnSessionUnreadable(AiSessionUnreadable report) =>
+        Status = $"That conversation could not be read. It has been kept at {report.KeptPath}.";
 
     /// <summary>Moves whatever has accumulated onto the screen, in one property change per kind.</summary>
     private void Flush(AiTurnViewModel turn)
@@ -730,12 +997,28 @@ public class AiAssistantViewModel : ReactiveTool
     ///
     /// <para>The turn being started is excluded — it is already in <see cref="Turns"/> by the time this runs,
     /// and its own context is what the current message carries.</para>
+    ///
+    /// <para><b>A restored turn replays like any other</b> (#849): it carries the marked answer it was written
+    /// with, and its question line is the one it was stored with rather than one re-rendered from today's
+    /// wording — see <see cref="AiTurnViewModel.RestoredAskedLine"/>. So a follow-up asked after a restart
+    /// continues the conversation instead of starting one.</para>
+    ///
+    /// <para><b>Which turns went in is recorded on the turn</b>, because the stored record says what the model
+    /// was sent and that cannot be recomputed later: by the time this turn is written, a newer turn may have
+    /// changed what "the turns with answers" means.</para>
     /// </summary>
-    private IReadOnlyList<AiExchange> HistoryFor(AiTurnViewModel current) =>
-        Turns
+    private IReadOnlyList<AiExchange> HistoryFor(AiTurnViewModel current)
+    {
+        var replayed = Turns
             .Where(t => !ReferenceEquals(t, current) && t.HasAnswer)
+            .ToList();
+
+        current.ReplayedTurnIds = replayed.Select(t => t.Id).ToList();
+
+        return replayed
             .Select(t => new AiExchange(DescribeAsked(t), t.MarkedAnswer))
             .ToList();
+    }
 
     /// <summary>
     /// The question side of an earlier turn, as the model is shown it again: which preset, which passage, and
@@ -759,6 +1042,11 @@ public class AiAssistantViewModel : ReactiveTool
     /// </summary>
     internal static string DescribeAsked(AiTurnViewModel turn)
     {
+        // A turn read off disk replays the line it was stored with. The record keeps that line precisely so a
+        // later change to the wording below cannot alter what a restored conversation tells the model it was
+        // asked — a record of what a model saw that re-renders itself is not a record. (#849)
+        if (turn.RestoredAskedLine is { Length: > 0 } stored) return stored;
+
         var opening = $"\u00ab{turn.PresetLabel}\u00bb";
         var head = string.IsNullOrWhiteSpace(turn.Citation) ? opening : $"{opening} \u2014 {turn.Citation}";
         return turn.HasQuestion ? $"{head}: {turn.Question!.Trim()}" : head;

--- a/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
+++ b/src/CST.Avalonia/ViewModels/AiTurnViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
+using CST.Avalonia.Models;
 using CST.Avalonia.Services.Ai;
 using CST.Search;
 using ReactiveUI;
@@ -16,6 +17,13 @@ namespace CST.Avalonia.ViewModels;
 /// start of the next request, so asking for a translation destroyed the explanation you were reading and there
 /// was no way to compare the two, scroll back, or see what you had already asked. A reader working through a
 /// passage asks several things about it; each one is kept.</para>
+///
+/// <para><b>And it outlives the session.</b> A turn is written to disk when it ends and rebuilt at the next
+/// launch (<see cref="ToRecord"/> / <see cref="FromRecord"/>, #849), so everything the panel renders has to be
+/// reachable from the turn rather than computed from something the panel happens to still be holding. That is
+/// why the structured originals now sit beside the display strings they produce: the citation beside its two
+/// rendered lines, the token report beside <see cref="Usage"/>, the duration beside <see cref="Elapsed"/>.
+/// Nothing bound in the panel changed when they arrived — the strings are still the strings.</para>
 /// </summary>
 public sealed class AiTurnViewModel : ReactiveObject
 {
@@ -31,6 +39,19 @@ public sealed class AiTurnViewModel : ReactiveObject
     }
 
     public AiTask Task { get; }
+
+    /// <summary>
+    /// Identity within the conversation, so a later turn's record can say which turns were replayed to the
+    /// model ahead of it (<c>AiSentRecord.ReplayedTurnIds</c>) without copying their text. (#849)
+    ///
+    /// <para>Minted here rather than at save time, because the id has to be stable while the turn is on screen:
+    /// the turn that replays this one is written before this one is written again.</para>
+    /// </summary>
+    internal string Id { get; private set; } = AiSession.NewId();
+
+    /// <summary>When the reader asked. Set at construction; carried through a save and a restore, so a
+    /// reopened conversation reports when it happened rather than when it was reloaded. (#849)</summary>
+    internal DateTimeOffset When { get; private set; } = DateTimeOffset.Now;
 
     /// <summary>The reader's own question, kept so the turn is legible later and so Retry can repeat it.</summary>
     public string? Question { get; }
@@ -159,6 +180,21 @@ public sealed class AiTurnViewModel : ReactiveObject
         internal set => this.RaiseAndSetIfChanged(ref _citation, value);
     }
 
+    /// <summary>
+    /// The citation the two rendered lines above were built FROM — book id, book name, reference and pages.
+    /// (#849)
+    ///
+    /// <para><b>Kept because the rendered lines cannot be un-rendered.</b> <b>[fsnow]</b>: <i>"A restored turn
+    /// should be able to reopen its book and restore the selection, as something the reader chooses rather
+    /// than something that happens on load."</i> A turn holding only <c>"Mahāvaggapāḷi — para 12"</c> is
+    /// readable and unnavigable — nothing in that string names a file to open. The panel had this object for
+    /// exactly the length of one <c>Started</c> event and dropped it.</para>
+    ///
+    /// <para>Not bound to anything: the chrome stays derived from it, which is the rule that makes a false
+    /// citation impossible.</para>
+    /// </summary>
+    internal CitationRef? StructuredCitation { get; set; }
+
     private string _citationDetail = "";
     public string CitationDetail
     {
@@ -252,6 +288,16 @@ public sealed class AiTurnViewModel : ReactiveObject
         }
     }
 
+    /// <summary>
+    /// The token counts <see cref="Usage"/> was printed from, as the provider reported them. (#849)
+    ///
+    /// <para>Stored as numbers rather than as that line, for two reasons the line cannot satisfy: it is run
+    /// through <c>:N0</c>, so the same turn reads <c>1,024</c> or <c>1.024</c> depending on the machine that
+    /// wrote the file, and a future "what has this conversation cost" can add numbers up and can never add up
+    /// strings.</para>
+    /// </summary>
+    internal AiUsageReport? UsageReport { get; set; }
+
     private string _elapsed = "";
     /// <summary>How long this turn took, kept after it finishes. A reader deciding whether to ask a slow model
     /// another question wants the last one's cost in front of them.</summary>
@@ -265,6 +311,15 @@ public sealed class AiTurnViewModel : ReactiveObject
             this.RaisePropertyChanged(nameof(HasFooter));
         }
     }
+
+    /// <summary>
+    /// The duration <see cref="Elapsed"/> was printed from. The panel's stopwatch is restarted by the next
+    /// turn, so this is the only thing that still knows how long this one took once it has ended. (#849)
+    ///
+    /// <para>A duration rather than <c>"4.2s"</c> for the same reason as the token counts — and because
+    /// <c>"1m 3s"</c> cannot be compared, summed, or reformatted.</para>
+    /// </summary>
+    internal TimeSpan? ElapsedTime { get; set; }
 
     /// <summary>Time and tokens on one quiet line, the way a transcript reports what a turn cost.</summary>
     public string Footer => string.Join(" · ", new[] { Elapsed, Usage }.Where(s => !string.IsNullOrEmpty(s)));
@@ -303,4 +358,238 @@ public sealed class AiTurnViewModel : ReactiveObject
         get => _isRunning;
         internal set => this.RaiseAndSetIfChanged(ref _isRunning, value);
     }
+
+    // ---- What the record needs and the screen does not show ---------------------------------------
+
+    /// <summary>Which connection answered, and which model. (#849) An answer is not attributable without them,
+    /// and a conversation spanning a model change is the ordinary case rather than a corner of it. They reach
+    /// the turn on the <c>Started</c> event — see <c>AiTurnContext.ProviderId</c>.</summary>
+    internal string? ProviderId { get; set; }
+
+    /// <inheritdoc cref="ProviderId"/>
+    internal string? ModelId { get; set; }
+
+    /// <summary>
+    /// Where the reader was standing when they asked — #434's two-anchor token, captured at turn start from the
+    /// book window's rolling position. (#849)
+    ///
+    /// <para>Not redundant with <see cref="StructuredCitation"/>: the citation is where the answer POINTS, this
+    /// is where the reader WAS. Null where the anchor cache had not built; a turn is worth keeping
+    /// without one.</para>
+    /// </summary>
+    internal ReadingPositionToken? ReadingPosition { get; set; }
+
+    /// <summary>
+    /// The turns that were actually replayed to the model ahead of this one, oldest first, as
+    /// <see cref="Id"/> values. (#849)
+    ///
+    /// <para>Written by the panel's <c>HistoryFor</c> — the same pass that builds the exchanges — rather than
+    /// recomputed at save time. Recomputing it would answer "which turns would be replayed NOW", and by the
+    /// time a turn is written a later one may have changed that: a record of what a model saw has to be taken
+    /// from the sending, not from the transcript afterwards.</para>
+    /// </summary>
+    internal IReadOnlyList<string> ReplayedTurnIds { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// The question line this turn was replayed to the model WITH, as it was stored — set only on a turn
+    /// rebuilt from disk. (#849)
+    ///
+    /// <para><b>Why a restored turn does not re-render its own history line.</b>
+    /// <c>AiAssistantViewModel.DescribeAsked</c> composes that line from today's wording; a later change to it
+    /// — a different dash, the preset label dropped — would make every restored conversation replay something
+    /// different from what the model was shown the first time. The record stores the line for exactly that
+    /// reason, so the restore path honours it and <c>DescribeAsked</c> prefers it when it is there.</para>
+    /// </summary>
+    internal string? RestoredAskedLine { get; private set; }
+
+    // ---- Stored and restored (#849) --------------------------------------------------------------
+
+    /// <summary>
+    /// This turn as it is kept on disk.
+    ///
+    /// <para><b>Deliberately next door to <see cref="FromRecord"/>.</b> The two have to stay symmetrical — a
+    /// field written and not read back is a turn that reopens wrong, and nothing else in the app would notice
+    /// — and keeping them apart is how that happens. The rendered forms are NOT stored: the blocks are
+    /// re-parsed from the answer, the citation lines are rebuilt from
+    /// <see cref="StructuredCitation"/>, and usage and elapsed are re-formatted, so a change to any of those
+    /// renderers reaches old conversations too.</para>
+    /// </summary>
+    internal AiTurnRecord ToRecord() => new()
+    {
+        Id = Id,
+        Task = Task,
+        Question = Question,
+        // The line as the model saw it. Prefers a restored turn's own stored line over re-rendering it.
+        AskedLine = AiAssistantViewModel.DescribeAsked(this),
+        Answer = NullIfEmpty(Answer),
+        MarkedAnswer = NullIfEmpty(MarkedAnswer),
+        Reasoning = NullIfEmpty(Reasoning),
+        Citation = ToRecord(StructuredCitation),
+        Subject = NullIfEmpty(Subject),
+        Notices = Notices.ToList(),
+        IsPartialPassage = IsPartialPassage,
+        InputTokens = UsageReport?.InputTokens,
+        OutputTokens = UsageReport?.OutputTokens,
+        ElapsedMs = ElapsedTime is { } elapsed ? (long)elapsed.TotalMilliseconds : null,
+        // The record's setter folds "" to null, so the live view model's empty-string convention needs no
+        // translation here.
+        Status = Status,
+        Failed = Failed,
+        Sent = ToRecord(Sent, ReplayedTurnIds),
+        ProviderId = ProviderId,
+        ModelId = ModelId,
+        When = When,
+        ReadingPosition = ReadingPosition,
+    };
+
+    /// <summary>
+    /// A turn rebuilt from disk, rendering as the live one that produced it did. (#849)
+    ///
+    /// <para><b>[fsnow]</b> chose <i>"Restore the last session silently"</i>, so this makes no model call and
+    /// asks nothing of the reader: it is the same kind of restore as a book and its reading position.</para>
+    ///
+    /// <para><see cref="IsRunning"/> is false and the answer is published — <see cref="Blocks"/> only exist
+    /// after <see cref="PublishAnswer"/>, so a turn restored without it would show an empty answer with a
+    /// correct <see cref="Answer"/> string behind it.</para>
+    /// </summary>
+    /// <param name="byId">
+    /// Every turn in the session, by id, so <c>Sent.History</c> can be rebuilt from the ids the record stores
+    /// instead of from copies of the answers. An id that resolves to nothing is skipped rather than refused —
+    /// a turn deleted from a session by hand leaves one, and losing the whole conversation over a dangling
+    /// reference is the failure this layer exists to avoid.
+    /// </param>
+    internal static AiTurnViewModel FromRecord(
+        AiTurnRecord record, IReadOnlyDictionary<string, AiTurnRecord>? byId = null)
+    {
+        var turn = new AiTurnViewModel(record.Task, record.Question)
+        {
+            Id = string.IsNullOrEmpty(record.Id) ? AiSession.NewId() : record.Id,
+            When = record.When,
+            StructuredCitation = ToLive(record.Citation),
+            Subject = record.Subject ?? "",
+            IsPartialPassage = record.IsPartialPassage,
+            ProviderId = record.ProviderId,
+            ModelId = record.ModelId,
+            ReadingPosition = record.ReadingPosition,
+            ReplayedTurnIds = record.Sent?.ReplayedTurnIds?.ToList() ?? (IReadOnlyList<string>)Array.Empty<string>(),
+            RestoredAskedLine = NullIfEmpty(record.AskedLine),
+            Status = record.Status ?? "",
+            Failed = record.Failed,
+            // Never running. A turn read off disk has nowhere to stream to.
+            IsRunning = false,
+        };
+
+        // The chrome, rebuilt from the citation rather than read back as text — the same rule as on a live
+        // turn, and the reason the structured citation is what gets stored.
+        turn.Citation = AiAssistantViewModel.Describe(turn.StructuredCitation!);
+        turn.CitationDetail = AiAssistantViewModel.DescribeCitationDetail(turn.StructuredCitation!);
+
+        if (record.Answer is { Length: > 0 } answer) turn.AppendAnswer(answer);
+
+        // The marked half falls back to the stripped one, which is what a session written before #991 has.
+        // Replaying nothing would be worse than replaying a marker-free answer: the follow-up would lose the
+        // turn entirely.
+        turn.AppendMarkedAnswer(record.MarkedAnswer ?? record.Answer ?? "");
+
+        if (record.Reasoning is { Length: > 0 } reasoning) turn.AppendReasoning(reasoning);
+
+        foreach (var notice in record.Notices) turn.Notices.Add(notice);
+        turn.RaiseNoticesChanged();
+
+        if (record.InputTokens is not null || record.OutputTokens is not null)
+        {
+            turn.UsageReport = new AiUsageReport(record.InputTokens, record.OutputTokens);
+            turn.Usage = AiAssistantViewModel.FormatUsage(turn.UsageReport);
+        }
+
+        if (record.ElapsedMs is { } ms)
+        {
+            turn.ElapsedTime = TimeSpan.FromMilliseconds(ms);
+            turn.Elapsed = AiAssistantViewModel.FormatElapsed(turn.ElapsedTime.Value);
+        }
+
+        turn.Sent = ToLive(record.Sent, byId);
+
+        // Last, because the blocks are parsed from whatever the builder holds by then.
+        turn.PublishAnswer();
+        turn.PublishReasoning();
+
+        return turn;
+    }
+
+    /// <summary>The stored form of a citation. Null stays null: a failed turn often has none.</summary>
+    private static AiCitationRecord? ToRecord(CitationRef? citation) => citation is null
+        ? null
+        : new AiCitationRecord
+        {
+            BookId = citation.BookId,
+            BookName = citation.BookName,
+            NormalizedReference = citation.NormalizedReference,
+            Pages = citation.Pages
+                .Select(p => new AiPageRecord { Edition = p.Edition, Volume = p.Volume, Number = p.Number })
+                .ToList(),
+        };
+
+    /// <inheritdoc cref="ToRecord(CitationRef?)"/>
+    private static CitationRef? ToLive(AiCitationRecord? record) => record is null
+        ? null
+        : new CitationRef(
+            record.BookId,
+            record.BookName,
+            record.NormalizedReference,
+            record.Pages.Select(p => new SnippetPageRef(p.Edition, p.Volume, p.Number)).ToList());
+
+    /// <summary>
+    /// The stored form of what a turn sent: the fields and both prompt halves by value, the replayed
+    /// conversation by REFERENCE.
+    ///
+    /// <para>By reference because #991 replays every earlier answered turn, so copying the history into each
+    /// turn would put 29 answers inside turn 30 and 435 copies of them in a 30-turn file. Nothing is lost: a
+    /// written turn never changes, so the ids plus each referenced turn's stored asked-line and marked answer
+    /// rebuild it exactly.</para>
+    /// </summary>
+    private static AiSentRecord? ToRecord(SentContext? sent, IReadOnlyList<string> replayedTurnIds) =>
+        sent is null
+            ? null
+            : new AiSentRecord
+            {
+                Fields = sent.Fields.Select(f => new AiSentFieldRecord { Name = f.Name, Value = f.Value })
+                    .ToList(),
+                SystemPrompt = sent.SystemPrompt,
+                UserContent = sent.UserContent,
+                ReplayedTurnIds = replayedTurnIds.ToList(),
+            };
+
+    /// <inheritdoc cref="ToRecord(SentContext?, IReadOnlyList{string})"/>
+    private static SentContext? ToLive(
+        AiSentRecord? record, IReadOnlyDictionary<string, AiTurnRecord>? byId)
+    {
+        if (record is null) return null;
+
+        var history = new List<ChatMessage>();
+        foreach (var id in record.ReplayedTurnIds)
+        {
+            if (byId is null || !byId.TryGetValue(id, out var earlier)) continue;
+
+            var asked = earlier.AskedLine;
+            // The same fallback as on the turn itself, for a pre-#991 session.
+            var answer = earlier.MarkedAnswer ?? earlier.Answer;
+
+            // The orchestrator's own replay rule: a pair with either half missing was never sent, so it must
+            // not appear in the record of what was.
+            if (string.IsNullOrWhiteSpace(asked) || string.IsNullOrWhiteSpace(answer)) continue;
+
+            history.Add(new ChatMessage(ChatRole.User, asked!));
+            history.Add(new ChatMessage(ChatRole.Assistant, answer!));
+        }
+
+        // Null rather than an empty list, so HasHistory reads false for a one-shot turn exactly as it did live.
+        return new SentContext(
+            record.Fields.Select(f => new SentField(f.Name, f.Value)).ToList(),
+            record.SystemPrompt,
+            record.UserContent,
+            history.Count == 0 ? null : history);
+    }
+
+    private static string? NullIfEmpty(string? text) => string.IsNullOrEmpty(text) ? null : text;
 }


### PR DESCRIPTION
Part of #849 — the wiring half of P2 ([ASSISTANT_SESSIONS.md](docs/features/planned/ASSISTANT_SESSIONS.md) §3.2). With the store (#996) and the conversation (#995) already in, this is the change that makes a reader's transcript survive a restart. Does not close #849: "take me back" (P5) is still open, and sessions/compaction are #997/#998.

**What changes**
- **Capture** what the record needs, which the panel was dropping: `ProviderId`/`ModelId` on `AiTurnContext`, the structured `AiUsageReport` and the elapsed `TimeSpan` kept beside their formatted strings, the `CitationRef` kept beside the display lines, and a `ReadingPositionToken` per turn (#434) via a new `ReaderState.ReadingPosition`.
- **Save** at every `EndTurn` — completed, failed, or stopped. The first turn to end creates the session, names it (**[fsnow]**: *"Auto from the first turn, renamable"*), and writes `ApplicationState.ActiveAssistantSessionId`. A failed save never breaks a turn.
- **Restore** silently at launch (**[fsnow]**: *"Restore the last session silently"*) — `AiTurnViewModel.FromRecord` rebuilds a turn that renders identically to a live one, with `Sent.History` reconstructed from the stored `ReplayedTurnIds`, so a follow-up after a restart replays the restored turns' marked answers.
- **`NewConversationCommand`** replaces `ClearCommand`/`Clear()`, which are removed — **[fsnow]**: *"'Clear' … is not relevant."*

**Review fixes** (Fable, "mergeable with named fixes", all applied in `db7270c`): the unreadable-file notice was raised on a thread-pool continuation and assigned a bound property, so it threw inside the store's catch and told the reader nothing; and restore mapped its records outside its own guard while the app awaited it ahead of book-window restore, so one bad stored duration could open the app with no books. Plus: the restore guard is re-checked after its await; `HistoryFor` applies the orchestrator's whitespace rule so `ReplayedTurnIds` matches the wire; auto-names are cut on a text element, not through a surrogate pair; two `[fsnow]` clauses no longer carry appended agent gloss.

**The one thing for the maintainer.** Your first comment on #849 says *"#850 should land before or with this, not after"* — and this branch has the command but not the **+** button, which is a Kestrel task (#850). So merging this ships persistence with no way to start a new conversation, the state you said not to ship. Your call: merge and have Kestrel bind the button straight after (one line, the command exists), or hold this until the button is on the branch.

**Recorded, not fixed** (plan §3.2, as a dated fact): there is no shutdown drain — a turn still streaming at Quit is lost, and a session's first turn ending inside the shutdown state save can be orphaned until P3 lists it.

**Tests.** Main suite 2907 → **2936 passed, 0 failed**, 18 skipped; UiTests 13/13. 27 cases in the wiring suite, including four for the review findings. One test documents what it cannot pin: the posted path needs a running dispatcher, which no suite here has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
